### PR TITLE
Exclude "update" from clojure.core

### DIFF
--- a/src/rethinkdb/query.clj
+++ b/src/rethinkdb/query.clj
@@ -1,7 +1,7 @@
 (ns rethinkdb.query
   (:refer-clojure :exclude [count filter map get not mod replace merge
                             reduce make-array distinct keys nth min max
-                            do fn sync time])
+                            do fn sync time update])
   (:require [clojure.data.json :as json]
             [clojure.walk :refer [postwalk postwalk-replace]]
             [rethinkdb.net :refer [send-start-query] :as net]


### PR DESCRIPTION
Removes a warning when using Clojure 1.7.0.