### PR TITLE
replace zipmap across keys, vals

### DIFF
--- a/src/rethinkdb/query_builder.clj
+++ b/src/rethinkdb/query_builder.clj
@@ -2,14 +2,12 @@
   (:require [clojure.data.json :as json]
             [clj-time.coerce :as c]
             [rethinkdb.types :refer [tt->int qt->int]]
-            [rethinkdb.utils :refer [snake-case]]))
+            [rethinkdb.utils :as u :refer [snake-case]]))
 
 (declare parse-term)
 
 (defn snake-case-keys [m]
-  (into {}
-    (for [[k v] m]
-      [(snake-case k) v])))
+  (u/mapk snake-case m))
 
 (defn term [term args & [optargs]]
   {::term term
@@ -32,7 +30,7 @@
   (parse-term (term :MAKE_ARRAY arg)))
 
 (defmethod parse-arg :map [arg]
-  (zipmap (keys arg) (map parse-arg (vals arg))))
+  (u/mapv parse-arg arg))
 
 (defmethod parse-arg :time [arg]
   (parse-term (term :EPOCH_TIME [(c/to-epoch arg)])))

--- a/src/rethinkdb/response.clj
+++ b/src/rethinkdb/response.clj
@@ -1,6 +1,7 @@
 (ns rethinkdb.response
   (:require [clj-time.core :as t]
-            [clj-time.coerce :as c]))
+            [clj-time.coerce :as c]
+            [rethinkdb.utils :as u]))
 
 (declare parse-response)
 
@@ -36,7 +37,7 @@
 (defmethod parse-response :map [resp]
   (if-let [reql-type (:$reql_type$ resp)]
     (parse-reql-type resp)
-    (zipmap (keys resp) (map parse-response (vals resp)))))
+    (u/mapv parse-response resp)))
 
 (defmethod parse-response :default [resp]
   resp)

--- a/src/rethinkdb/utils.clj
+++ b/src/rethinkdb/utils.clj
@@ -28,3 +28,17 @@
 
 (defn snake-case [s]
   (string/replace (name s) #"-" "_"))
+
+(defn mapk
+  "Applies the supplied function to every key in the supplied
+  map. Returns a transformed map."
+  [f m]
+  (into {} (for [[k v] m]
+             [(f k) v])))
+
+(defn mapv
+  "Applies the supplied function to every value in the supplied
+  map. Returns a transformed map."
+  [f m]
+  (into {} (for [[k v] m]
+             [k (f v)])))


### PR DESCRIPTION
There was a discussion recently on the clojure mailing list about how "keys" and "vals" are NOT guaranteed to return items in the same order for a given map. Let's get ahead of the game and fix this up here. Thoughts?