### PR TITLE
Fixed thread-safety issues with connection

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,7 @@
           :src-dir-uri "https://github.com/apa512/clj-rethinkdb/blob/master/"
           :src-linenum-anchor-prefix "L"}
   :dependencies [[org.clojure/clojure "1.6.0"]
+                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]
                  [org.clojure/data.json "0.2.6"]
                  [org.flatland/protobuf "0.8.1"]
                  [rethinkdb-protobuf "0.3.0"]

--- a/src/rethinkdb/net.clj
+++ b/src/rethinkdb/net.clj
@@ -1,5 +1,6 @@
 (ns rethinkdb.net
   (:require [clojure.data.json :as json]
+            [clojure.core.async :as async]
             [rethinkdb.query-builder :refer [parse-query]]
             [rethinkdb.response :refer [parse-response]]
             [rethinkdb.utils :refer [str->bytes int->bytes bytes->int pp-bytes]])
@@ -48,7 +49,7 @@
           json (read-str in length)]
       (json/read-str json :key-fn keyword))))
 
-(defn send-query [conn token query]
+(defn send-query-sync [conn token query]
   (let [json (json/write-str query)
         {:keys [in out]} @conn
         n (count json)]
@@ -68,6 +69,91 @@
                    (swap! (:conn conn) update-in [:waiting] #(conj % token))
                    (Cursor. conn token resp)))
         (throw (Exception. (first resp)))))))
+
+
+(defn read-response* [in]
+  (let [recvd-token (byte-array 8)
+        length (byte-array 4)]
+    (.read in recvd-token 0 8)
+    (.read in length 0 4)
+    (let [recvd-token (bytes->int recvd-token 8)
+          length (bytes->int length 4)
+          json (read-str in length)]
+      [recvd-token json])))
+
+
+(defn send-query* [out [token json]]
+  (send-int out token 8)
+  (send-int out (count json) 4)
+  (send-str out json))
+
+
+(defn make-connection-loops [in out]
+  (let [recv-chan (async/chan)
+        send-chan (async/chan)
+        pub       (async/pub recv-chan first)
+        ;; Receive loop
+        recv-loop (async/go-loop []
+                    (when (try
+                            (let [resp (read-response* in)]
+                              (async/>! recv-chan resp))
+                            (catch java.net.SocketException e
+                              false))
+                      (recur)))
+        ;; Send loop
+        send-loop (async/go-loop []
+                    (when-let [query (async/<! send-chan)]
+                      (send-query* out query)
+                      (recur)))]
+    ;; Return as map to merge into connection
+    {:pub pub
+     :loops [recv-loop send-loop]
+     :r-ch recv-chan
+     :ch send-chan}))
+
+(defn close-connection-loops [conn]
+  (let [{:keys [pub ch r-ch] [recv-loop send-loop] :loops} @conn]
+    (async/unsub-all pub)
+    ;; Close send channel and wait for loop to complete
+    (async/close! ch)
+    (async/<!! send-loop)  
+    ;; Close recv channel 
+    (async/close! r-ch)))
+
+
+(defn send-query-async* [conn token query]
+  (let [chan (async/chan)
+        {:keys [pub ch]} @conn]
+    (async/sub pub token chan)
+    (async/>!! ch [token query])
+    (let [[recvd-token json] (async/<!! chan)]
+      (when-not (= recvd-token token)
+        (println "Got:" recvd-token "expected:" token)
+        (println json))
+      (assert (= recvd-token token))
+      (async/unsub pub token chan)
+      (json/read-str json :key-fn keyword))))
+
+
+(defn send-query-async [conn token query]
+  (let [json (json/write-str query)
+        {type :t resp :r} (send-query-async* conn token json) 
+        resp (parse-response resp)]
+    (condp get type
+      #{1} (first resp)
+      #{2} (do
+             (swap! (:conn conn) update-in [:waiting] #(disj % token))
+             resp)
+      #{3 5} (if (get (:waiting @conn) token)
+               (lazy-seq (concat resp (send-continue-query conn token)))
+               (do
+                 (swap! (:conn conn) update-in [:waiting] #(conj % token))
+                 (Cursor. conn token resp)))
+      (throw (Exception. (first resp))))))
+
+
+(def send-query send-query-async)
+
 
 (defn send-start-query [conn token query]
   (send-query conn token (parse-query :START query)))

--- a/test/rethinkdb/connection_test.clj
+++ b/test/rethinkdb/connection_test.clj
@@ -4,6 +4,18 @@
             [rethinkdb.core :refer :all]
             [rethinkdb.query :as r]))
 
+;;; Refernece performance 
+;; performance (connect)          "Elapsed time: 4021.701763 msecs"
+;; performance reusing connection "Elapsed time: 3999.424348 msecs"
+
+(defmacro timed
+  "Like clojure.core/time but returns the duration"
+  {:added "1.0"}
+  [expr]
+  `(let [start# (. System (nanoTime))]
+     ~expr
+     (/ (double (- (. System (nanoTime)) start#)) 1000000.0)))
+
 (def test-db "cljrethinkdb_test")
 
 (defn setup [test-fn]
@@ -28,19 +40,45 @@
 
 ;; Uncomment to run test
 (deftest connection-speed-test
-  (println "performance (connect)") 
+  (println "performance (connection per query)") 
     (let [conn connect]
       (test-query conn #(close %))
       (is true))
 
-  (println "performance reusing connection") 
+  (println "performance (reusing connection")
     (let [conn (connect)]
       (test-query (constantly conn) identity)
       (close conn)
       (is true))
 
-  (println "performance pooled connection") 
+  (println "performance (parallel, one connection)")
+    (let [conn (connect)]
+      (time
+        (pmap (fn [v] (r/run query conn))
+              (range 100)))
+      (is true))
+
+  (println "performance (pooled connection")  
     (let [conn connect]
       ;(test-query conn identity)
+      (is true))
+    
+  (println "multiple connection test") 
+    (let [conn1 (connect)
+          conn2 (connect) 
+          conn3 (connect)]
+      (r/run query conn1)
+      (future
+        (do
+          (r/run query conn2)
+          (close conn2)))
+      (future
+        (with-open [conn (connect)]
+          (r/run query conn)))
+      (future
+        (close conn1))
+      (r/run query conn3)
+      (close conn3)
+      (is true)  
       (is true)))
 

--- a/test/rethinkdb/connection_test.clj
+++ b/test/rethinkdb/connection_test.clj
@@ -1,0 +1,46 @@
+(ns rethinkdb.connection-test
+  (:require [clj-time.core :as t]
+            [clojure.test :refer :all]
+            [rethinkdb.core :refer :all]
+            [rethinkdb.query :as r]))
+
+(def test-db "cljrethinkdb_test")
+
+(defn setup [test-fn]
+  (with-open [conn (connect)]
+    (if (some #{test-db} (r/run (r/db-list) conn))
+      (r/run (r/db-drop test-db) conn))
+    (r/run (r/db-create test-db) conn)
+    (test-fn)))
+
+(use-fixtures :once setup)
+
+(def query
+  (-> (r/db test-db)
+      (r/table-list)))
+
+(defn test-query [open close]
+  (time
+    (doseq [n (range 100)]
+      (let [conn (open)]
+        (r/run query conn)
+        (close conn)))))
+
+;; Uncomment to run test
+(deftest connection-speed-test
+  (println "performance (connect)") 
+    (let [conn connect]
+      (test-query conn #(close %))
+      (is true))
+
+  (println "performance reusing connection") 
+    (let [conn (connect)]
+      (test-query (constantly conn) identity)
+      (close conn)
+      (is true))
+
+  (println "performance pooled connection") 
+    (let [conn connect]
+      ;(test-query conn identity)
+      (is true)))
+

--- a/test/rethinkdb/core_test.clj
+++ b/test/rethinkdb/core_test.clj
@@ -4,6 +4,7 @@
             [rethinkdb.core :refer :all]
             [rethinkdb.query :as r]))
 
+
 (def conn (connect))
 (def test-db "cljrethinkdb_test")
 


### PR DESCRIPTION
Each connection now has a dedicated reader and writer core.async go block for serially reading/writing the socket. This way, a connection can be used by many threads without worry that they will adversely affect each other.

There is a minor performance penalty to connecting and disconnecting connections, as the core.async resources need to be created and destroyed too (measured at approx. 7% slower than before), but no measurable performance penalty was observed for the actual use of the connection.

Note that this PR adds a dependency on core.async.