### PR TITLE
Update #'rethinkdb.query/filter to allow optargs

### DIFF
--- a/src/rethinkdb/query.clj
+++ b/src/rethinkdb/query.clj
@@ -180,8 +180,8 @@
   By default RethinkDB will ignore documents where a specified field is missing.
   Passing ```{:default (r/error)}``` as an optional argument will cause any
   non-existence error to raise an exception."
-  [sq obj-or-func]
-  (term :FILTER [sq obj-or-func]))
+  [sq obj-or-func & [optargs]]
+  (term :FILTER [sq obj-or-func] optargs))
 
 ;;; Joins
 

--- a/src/rethinkdb/query.clj
+++ b/src/rethinkdb/query.clj
@@ -180,9 +180,15 @@
   of elements. The return type is the same as the type on which the function
   was called on.
 
-  By default RethinkDB will ignore documents where a specified field is missing.
-  Passing ```{:default (r/error)}``` as an optional argument will cause any
-  non-existence error to raise an exception."
+  Passing a ```:default``` optional argument can change the handling of
+  documents with missing fields.
+
+  - ```{:default true}``` will return documents with missing fields,
+    rather than ignore them.
+  - ```{:default (r/error))``` will cause any non-existence error to
+    raise an exception.
+  - ```{:default false}``` (the default) will ignore documents where
+    a specified field is missing."
   [sq obj-or-func & [optargs]]
   (term :FILTER [sq obj-or-func] optargs))
 

--- a/test/rethinkdb/core_test.clj
+++ b/test/rethinkdb/core_test.clj
@@ -227,14 +227,14 @@
 
     (testing "filter with default"
       (is (= [1 3 5 6]
-             (run (-> [{:id 1, :bool false}
-                       {:id 2, :bool true}
+             (run (-> [{:id 1, :apple "good"}
+                       {:id 2, :apple "bad"}
                        {:id 3}
-                       {:id 4, :bool true}
-                       {:id 5, :bool false}
+                       {:id 4, :apple "bad"}
+                       {:id 5, :apple "good"}
                        {:id 6}]
                       (r/filter (r/fn [row]
-                                  (r/not (r/get-field row :bool)))
+                                  (r/ne (r/get-field row :apple) "bad"))
                                 {:default true})
                       (r/get-field :id))))))
     (close conn)))

--- a/test/rethinkdb/core_test.clj
+++ b/test/rethinkdb/core_test.clj
@@ -226,17 +226,34 @@
                                                 x)))})))))))
 
     (testing "filter with default"
-      (is (= [1 3 5 6]
-             (run (-> [{:id 1, :apple "good"}
-                       {:id 2, :apple "bad"}
-                       {:id 3}
-                       {:id 4, :apple "bad"}
-                       {:id 5, :apple "good"}
-                       {:id 6}]
+      (let [twin-peaks [{:name "Cole", :job "Regional Bureau Chief"}
+                        {:name "Cooper", :job "FBI Agent"}
+                        {:name "Riley", :job "Colonel"}
+                        {:name "Briggs", :job "Major"}
+                        {:name "Harry", :job "Sheriff"}
+                        {:name "Hawk", :job "Deputy"}
+                        {:name "Andy", :job "Deputy"}
+                        {:name "Lucy", :job "Secretary"}
+                        {:name "Bobby"}]]
+        (is (= ["Hawk" "Andy" "Bobby"]
+               (run (-> twin-peaks
+                        (r/filter (r/fn [row]
+                                    (r/eq (r/get-field row :job) "Deputy"))
+                                  {:default true})
+                        (r/get-field :name)))))
+        (is (thrown?
+             Exception
+             (run (-> twin-peaks
                       (r/filter (r/fn [row]
-                                  (r/ne (r/get-field row :apple) "bad"))
-                                {:default true})
-                      (r/get-field :id))))))
+                                  (r/eq (r/get-field row :job) "Deputy"))
+                                {:default (r/error)})
+                      (r/get-field :name)))))
+        (is (= ["Hawk" "Andy"]
+               (run (-> twin-peaks
+                        (r/filter (r/fn [row]
+                                    (r/eq (r/get-field row :job) "Deputy"))
+                                  {:default false})
+                        (r/get-field :name)))))))
     (close conn)))
 
 (use-fixtures :once setup)

--- a/test/rethinkdb/core_test.clj
+++ b/test/rethinkdb/core_test.clj
@@ -224,6 +224,19 @@
                                 :b (-> [1 2]
                                        (r/map (r/fn [y]
                                                 x)))})))))))
+
+    (testing "filter with default"
+      (is (= [1 3 5 6]
+             (run (-> [{:id 1, :bool false}
+                       {:id 2, :bool true}
+                       {:id 3}
+                       {:id 4, :bool true}
+                       {:id 5, :bool false}
+                       {:id 6}]
+                      (r/filter (r/fn [row]
+                                  (r/not (r/get-field row :bool)))
+                                {:default true})
+                      (r/get-field :id))))))
     (close conn)))
 
 (use-fixtures :once setup)


### PR DESCRIPTION
Per the [docstring][1]:

> By default RethinkDB will ignore documents where a specified field is missing.
> Passing ```{:default (r/error)}``` as an optional argument will cause any
> non-existence error to raise an exception.

Currently, something like...
```clojure
(r/filter sq predicate {:default true})
```
...throws an exception:

> Wrong number of args (3) passed to: query/filter

[1]: https://github.com/apa512/clj-rethinkdb/blob/fb1423fafc6cc4c5e487d744f40c424e54ba3882/src/rethinkdb/query.clj#L180-L182