### PR TITLE
Import `connect` into query, connect docstring improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,9 @@ A RethinkDB client for Clojure. Tested with 1.16.x but should with work all vers
 ## Usage
 
 ```clojure
-(require '[rethinkdb.core :refer [connect close]])
 (require '[rethinkdb.query :as r])
 
-(with-open [conn (connect :host "127.0.0.1" :port 28015 :db "test")]
+(with-open [conn (r/connect :host "127.0.0.1" :port 28015 :db "test")]
   (r/run (r/db-create "test") conn)
 
   (-> (r/db "test")

--- a/src/rethinkdb/core.clj
+++ b/src/rethinkdb/core.clj
@@ -21,7 +21,10 @@
     (send-int out n 4)
     (send-str out auth-key)))
 
-(defn close [conn]
+(defn close
+  "Closes RethinkDB database connection, stops all running queries
+  and waits for response before returning"
+  [conn]
   (let [{:keys [socket out in waiting]} @conn]
     (doseq [token waiting]
       (send-stop-query conn token))

--- a/src/rethinkdb/query.clj
+++ b/src/rethinkdb/query.clj
@@ -5,6 +5,7 @@
   (:require [clojure.data.json :as json]
             [clojure.walk :refer [postwalk postwalk-replace]]
             [rethinkdb.net :refer [send-start-query] :as net]
+            [rethinkdb.core :as core]
             [rethinkdb.query-builder :refer [term parse-term]]))
 
 (defmacro fn [args & [body]]
@@ -12,6 +13,16 @@
         new-replacements (zipmap args new-args)
         new-terms (postwalk-replace new-replacements body)]
     (term :FUNC [new-args new-terms])))
+
+;;; Import connect
+
+(def connect
+  "Creates a database connection to a RethinkDB host
+  [& {:keys [host port token auth-key]
+       :or {host \"127.0.0.1\"
+            port 28015
+            token 0
+            auth-key \"\"}}" core/connect)
 
 ;;; Cursors
 

--- a/test/rethinkdb/core_test.clj
+++ b/test/rethinkdb/core_test.clj
@@ -265,4 +265,8 @@
                         (r/get-field :name)))))))
     (.close conn)))
 
+(deftest query-conn
+  (is (do (r/connect)
+          true)))
+
 (use-fixtures :once setup)

--- a/test/rethinkdb/core_test.clj
+++ b/test/rethinkdb/core_test.clj
@@ -1,11 +1,10 @@
 (ns rethinkdb.core-test
   (:require [clj-time.core :as t]
             [clojure.test :refer :all]
-            [rethinkdb.core :refer :all]
             [rethinkdb.query :as r]))
 
 
-(def conn (connect))
+(def conn (r/connect))
 (def test-db "cljrethinkdb_test")
 
 (defmacro db-run [& body]
@@ -54,7 +53,7 @@
                   (r/eq (r/get-field row :name) name)))))
 
 (deftest core-test
-  (with-open [conn (connect)]
+  (with-open [conn (r/connect)]
     (testing "manipulating databases"
       (is (= 1 (:dbs_created (r/run (r/db-create "cljrethinkdb_tmp") conn))))
       (is (= 1 (:dbs_dropped (r/run (r/db-drop "cljrethinkdb_tmp") conn))))
@@ -103,11 +102,11 @@
       (is (= (run (with-name "Pikachu")) [(first pokemons)])))
 
     (testing "run a query with an implicit database"
-      (with-open [conn-implicit-db (connect :db test-db)]
+      (with-open [conn-implicit-db (r/connect :db test-db)]
         (is (= (set (-> (r/table :pokedex) (r/run conn-implicit-db)))
                (set pokemons))))
       (testing "precedence of db connections"
-        (with-open [conn-implicit-db (connect :db "nonexistent_db")]
+        (with-open [conn-implicit-db (r/connect :db "nonexistent_db")]
           (is (= (set (-> (r/db test-db) (r/table :pokedex) (r/run conn-implicit-db)))
                  (set pokemons))))))
 
@@ -119,7 +118,7 @@
         (r/sum [3 4]) 7))
 
     (testing "feeds"
-      (let [tmp-conn (connect)
+      (let [tmp-conn (r/connect)
             changes (future
                       (-> (r/db test-db)
                           (r/table :pokedex)


### PR DESCRIPTION
It is often a pain to have to import the `rethinkdb.core` namespace just to make a connection. This PR imports the connect function into the `rethinkdb.query` ns which is the most common ns for API consumers to be using.

I wasn't keen on using something like Potemkin for a single function, sing out if you've got alternative approaches or have an issue with this, otherwise I'll merge this in a few days.

- [x] Add documentation
- [x] Update tests to use new connect function?