### PR TITLE
Fix close method on Connection to use `this`

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject rethinkdb "0.9.40"
+(defproject rethinkdb "0.10.0-SNAPSHOT"
   :description "RethinkDB client"
   :url "http://github.com/apa512/clj-rethinkdb"
   :license {:name "Eclipse Public License"

--- a/src/rethinkdb/core.clj
+++ b/src/rethinkdb/core.clj
@@ -35,7 +35,7 @@
   IDeref
   (deref [_] @conn)
   Closeable
-  (close [_] (close conn)))
+  (close [this] (close this)))
 
 (defmethod print-method Connection
   [r writer]

--- a/test/rethinkdb/connection_test.clj
+++ b/test/rethinkdb/connection_test.clj
@@ -66,12 +66,12 @@
     (future
       (do
         (r/run query conn2)
-        (close conn1)))
+        (.close conn1)))
     (future
       (with-open [conn (connect)]
         (r/run query conn)))
     (future
-      (close conn2))
+      (.close conn2))
     (r/run query conn3)
-    (close conn3)
+    (.close conn3)
     (is true)))

--- a/test/rethinkdb/core_test.clj
+++ b/test/rethinkdb/core_test.clj
@@ -129,7 +129,7 @@
         (db-run (-> (r/table :pokedex)
                     (r/insert (take 10000 (repeat {:name "Test"})))))
         (is (= "Test" ((comp :name :new_val) (first @changes))))
-        (close tmp-conn)))
+        (.close tmp-conn)))
 
     (testing "document manipulation"
       (is (= (db-run (-> (r/table :pokedex)
@@ -263,6 +263,6 @@
                                     (r/eq (r/get-field row :job) "Deputy"))
                                   {:default false})
                         (r/get-field :name)))))))
-    (close conn)))
+    (.close conn)))
 
 (use-fixtures :once setup)


### PR DESCRIPTION
This is a pretty subtle bug, you will only run into it when you try to close a connection which has queries outstanding (e.g. changefeeds) using the `.close` method on the Connection. Before this PR there were two subtly different code paths that a closing connection could take:

1. Calling the close function in `rethinkdb.core` will deref `conn` (which is a Connection that implements `deref` to deref it's internal `conn` atom) and destructure the keys of the internal `conn` atom. 
    * When running `send-stop-query` on every outstanding query, we pass the Connection. 
    * Deeper in the call stack at `send-query`, we access the connection atom (without derefing it) by calling **`(:conn conn)` on the record**. 
    * We do our `swap!` to remove the `:waiting` token from the set and continue.
2. Calling the close method on the Connection directly will call the `close` function **with the conn atom directly**. 
    * The `conn` atom will deref and destructure because it also implements deref. 
    * However when we get down to `send-query` we are trying to call **`(:conn conn)` on the atom** which will return nil.
    * `swap!` will throw a NPE.

I'm not sure whether this is a breaking change or not, it fixes the behaviour of `.close`, so it's worth at least highlighting in the changelog and release notes.

There's two things we could do to make this kind of bug not happen in the future:
1. Move the `close` function inside the Connection. People should be able to call `close` and this will use the `close` method on the Connection. However in my limited testing this doesn't seem to be happening. I'm not quite sure why, I thought records defined their methods as functions in the ns they were defined in.
2. Give the connection many fields, rather than putting them all inside a single `conn` variable. The only things that should be mutable are the `:waiting` and `:token`, so they could go into atoms.

Thoughts?