### PR TITLE
Fix CONTINUE and STOP queries with implicit DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file. This change
 
 ### Fixed
 - Fix close method on Connection record [#50](https://github.com/apa512/clj-rethinkdb/pull/50)
+- Fix handling of sending CONTINUE queries to RethinkDB when using an implicit db on the connection. Affects any query that returns a Cursor. [#52](https://github.com/apa512/clj-rethinkdb/pull/52)
 
 ## [0.9.40]
 ### Changed

--- a/src/rethinkdb/net.clj
+++ b/src/rethinkdb/net.clj
@@ -99,7 +99,8 @@
 
 (defn send-query [conn token query]
   (let [{:keys [db]} @conn
-        query (if db ;; TODO: Could provide other global optargs too
+        query (if (and db (= 2 (count query))) ;; If there's only 1 element in query then this is a continue or stop query.
+                ;; TODO: Could provide other global optargs too
                 (concat query [{:db [(types/tt->int :DB) [db]]}])
                 query)
         json (json/write-str query)

--- a/test/rethinkdb/core_test.clj
+++ b/test/rethinkdb/core_test.clj
@@ -102,12 +102,12 @@
       (is (= (run (with-name "Pikachu")) [(first pokemons)])))
 
     (testing "run a query with an implicit database"
-      (with-open [conn-implicit-db (r/connect :db test-db)]
-        (is (= (set (-> (r/table :pokedex) (r/run conn-implicit-db)))
+      (with-open [conn (r/connect :db test-db)]
+        (is (= (set (-> (r/table :pokedex) (r/run conn)))
                (set pokemons))))
       (testing "precedence of db connections"
-        (with-open [conn-implicit-db (r/connect :db "nonexistent_db")]
-          (is (= (set (-> (r/db test-db) (r/table :pokedex) (r/run conn-implicit-db)))
+        (with-open [conn (r/connect :db "nonexistent_db")]
+          (is (= (set (-> (r/db test-db) (r/table :pokedex) (r/run conn)))
                  (set pokemons))))))
 
     (testing "aggregation"
@@ -118,7 +118,7 @@
         (r/sum [3 4]) 7))
 
     (testing "feeds"
-      (let [tmp-conn (r/connect)
+      (let [tmp-conn (r/connect :db test-db)
             changes (future
                       (-> (r/db test-db)
                           (r/table :pokedex)


### PR DESCRIPTION
- Fix handling of CONTINUE and STOP queries. Global optargs from the db
  connection were being appended to every query that was being sent if
  the db parameter was set on the connection. START queries have two
  elements in the vector: query type (START), and query. However
  CONTINUE and STOP queries only have a single query type in the vector, so
  the global optargs were getting appended as the second element in
  these vectors. This caused RethinkDB to throw an error as we weren't
  sending a valid query.
- Update changelog
- Add failing tests that pass with this fix.

To avoid these kinds of bugs in the future, it could be good to turn the query vector into a map with named elements.