### PR TITLE
Refactor tests, add table arities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file. This change
 - Add alias for `rethinkdb.core/connect` into `rethinkdb.query/connect` so you don't need to import the `rethinkdb.core` namespace. [#44](https://github.com/apa512/clj-rethinkdb/pull/44)
 - Add CHANGELOG.md [#47](https://github.com/apa512/clj-rethinkdb/pull/47)
 
+### Changed
+- Add new arity for the queries `table-drop`, and `table-list` which doesn't require a db. [#54](https://github.com/apa512/clj-rethinkdb/pull/54/files)
+- Add docstring to `rethinkdb.query` ns explaining DB priority [#54](https://github.com/apa512/clj-rethinkdb/pull/54/files)
+
 ### Fixed
 - Fix close method on Connection record [#50](https://github.com/apa512/clj-rethinkdb/pull/50)
 - Fix handling of sending CONTINUE queries to RethinkDB when using an implicit db on the connection. Affects any query that returns a Cursor. [#52](https://github.com/apa512/clj-rethinkdb/pull/52)

--- a/test/rethinkdb/core_test.clj
+++ b/test/rethinkdb/core_test.clj
@@ -3,21 +3,11 @@
             [clojure.test :refer :all]
             [rethinkdb.query :as r]))
 
-
-(def conn (r/connect))
 (def test-db "cljrethinkdb_test")
-
-(defmacro db-run [& body]
-  (cons 'do (for [term body]
-              `(-> (r/db test-db)
-                   ~term
-                   (r/run ~'conn)))))
+(def test-table :pokedex)
 
 (defn split-map [m]
   (map (fn [[k v]] {k v}) m))
-
-(defn run [term]
-  (r/run term conn))
 
 (def pokemons [{:national_no 25
                 :name "Pikachu"
@@ -30,242 +20,282 @@
                 :name "Bulbasaur"
                 :type ["Grass" "Poison"]})
 
-(defn setup [test-fn]
-  (if (some #{test-db} (r/run (r/db-list) conn))
-    (r/run (r/db-drop test-db) conn))
-  (r/run (r/db-create test-db) conn)
-  (test-fn))
+(defn ensure-table
+  "Ensures that an empty table \"table-name\" exists"
+  [table-name optargs conn]
+  (if (some #{table-name} (r/run (r/table-list) conn))
+    (r/run (r/table-drop table-name) conn))
+  (r/run (r/table-create (r/db test-db) table-name optargs) conn))
 
-(defn between-notional-no [from to]
-  (-> (r/db test-db)
-      (r/table :pokedex)
-      (r/between from to {:right-bound :closed})))
+(defn ensure-db
+  "Ensures that an empty database \"db-name\" exists"
+  [db-name conn]
+  (if (some #{db-name} (r/run (r/db-list) conn))
+    (r/run (r/db-drop db-name) conn))
+  (r/run (r/db-create db-name) conn))
 
-(def min-to-max
-  (-> (r/db test-db)
-      (r/table :pokedex)
-      (r/between r/minval r/maxval {:right-bound :closed})))
+(defn setup-each [test-fn]
+  (with-open [conn (r/connect :db test-db)]
+    (ensure-table (name test-table) {:primary-key :national_no} conn)
+    (test-fn)
+    (r/run (r/table-drop test-table) conn)))
 
-(defn with-name [name]
-  (-> (r/db test-db)
-      (r/table :pokedex)
-      (r/filter (r/fn [row]
-                  (r/eq (r/get-field row :name) name)))))
-
-(deftest core-test
+(defn setup-once [test-fn]
   (with-open [conn (r/connect)]
-    (testing "manipulating databases"
-      (is (= 1 (:dbs_created (r/run (r/db-create "cljrethinkdb_tmp") conn))))
-      (is (= 1 (:dbs_dropped (r/run (r/db-drop "cljrethinkdb_tmp") conn))))
-      (is (contains? (set (r/run (r/db-list) conn)) test-db)))
+    (ensure-db test-db conn)
+    (test-fn)
+    (r/run (r/db-drop test-db) conn)))
 
-    (testing "manipulating tables"
-      (db-run (r/table-create :tmp))
-      (are [term result] (contains? (set (split-map (db-run term))) result)
-        (-> (r/table :tmp)
-            (r/insert {:id (java.util.UUID/randomUUID)}))            {:inserted 1}
-        (r/table-create :pokedex {:primary-key :national_no})        {:tables_created 1}
-        (r/table-drop :tmp) {:tables_dropped 1}
-        (-> (r/table :pokedex) (r/index-create :tmp (r/fn [row] 1))) {:created 1}
-        (-> (r/table :pokedex)
-            (r/index-create :type (r/fn [row]
-                                    (r/get-field row :type))))       {:created 1}
-        (-> (r/table :pokedex) (r/index-rename :tmp :xxx))           {:renamed 1}
-        (-> (r/table :pokedex) (r/index-drop :xxx))                  {:dropped 1})
-      (is (= ["type"] (db-run (-> (r/table :pokedex) r/index-list)))))
+(deftest manipulating-databases
+  (with-open [conn (r/connect)]
+    (is (= 1 (:dbs_created (r/run (r/db-create "cljrethinkdb_tmp") conn))))
+    (is (= 1 (:dbs_dropped (r/run (r/db-drop "cljrethinkdb_tmp") conn))))
+    (is (contains? (set (r/run (r/db-list) conn)) test-db))))
 
+(deftest manipulating-tables
+  (with-open [conn (r/connect :db test-db)]
+    (are [term result] (contains? (set (split-map (r/run term conn))) result)
+      (r/table-create (r/db test-db) :tmp) {:tables_created 1}
+      (-> (r/table :tmp)
+          (r/insert {:id (java.util.UUID/randomUUID)})) {:inserted 1}
+      (r/table-drop :tmp) {:tables_dropped 1}
+
+      (-> (r/table test-table) (r/index-create :tmp (r/fn [row] 1))) {:created 1}
+      (-> (r/table test-table)
+          (r/index-create :type (r/fn [row]
+                                  (r/get-field row :type)))) {:created 1}
+      (-> (r/table test-table) (r/index-rename :tmp :xxx)) {:renamed 1}
+      (-> (r/table test-table) (r/index-drop :xxx)) {:dropped 1})
+    (is (= ["type"] (r/run (-> (r/table test-table) r/index-list) conn)))))
+
+(deftest manipulating-data
+  (with-open [conn (r/connect :db test-db)]
     (testing "writing data"
-      (are [term result] (contains? (set (split-map (db-run term))) result)
-        (-> (r/table :pokedex) (r/insert bulbasaur))          {:inserted 1}
-        (-> (r/table :pokedex) (r/insert pokemons))           {:inserted 2}
-        (-> (r/table :pokedex)
+      (are [term result] (contains? (set (split-map (r/run term conn))) result)
+        (-> (r/table test-table) (r/insert bulbasaur)) {:inserted 1}
+        (-> (r/table test-table) (r/insert pokemons)) {:inserted 2}
+        (-> (r/table test-table)
             (r/get 1)
-            (r/update {:japanese "Fushigidane"}))             {:replaced 1}
-        (-> (r/table :pokedex)
+            (r/update {:japanese "Fushigidane"})) {:replaced 1}
+        (-> (r/table test-table)
             (r/get 1)
             (r/replace (merge bulbasaur {:weight "6.9 kg"}))) {:replaced 1}
-        (-> (r/table :pokedex) (r/get 1) r/delete)            {:deleted 1}
-        (-> (r/table :pokedex) r/sync)                        {:synced 1}))
+        (-> (r/table test-table) (r/get 1) r/delete) {:deleted 1}
+        (-> (r/table test-table) r/sync) {:synced 1}))
 
     (testing "transformations"
-      (is (= [25 81] (db-run (-> (r/table :pokedex)
-                                 (r/order-by {:index (r/asc :national_no)})
-                                 (r/map (r/fn [row]
-                                          (r/get-field row :national_no))))))))
+      (is (= [25 81] (r/run (-> (r/table test-table)
+                                (r/order-by {:index (r/asc :national_no)})
+                                (r/map (r/fn [row]
+                                         (r/get-field row :national_no))))
+                            conn))))
 
     (testing "selecting data"
-      (is (= (set (db-run (r/table :pokedex))) (set pokemons)))
-      (is (= (db-run (-> (r/table :pokedex) (r/get 25))) (first pokemons)))
-      (is (= (into [] (db-run (-> (r/table :pokedex) (r/get-all [25 81])))) pokemons))
-      (is (= pokemons (sort-by :national_no (run min-to-max))))
-      (is (= (run (between-notional-no 80 81)) [(last pokemons)]))
-      (is (= (run (with-name "Pikachu")) [(first pokemons)])))
+      (is (= (set (r/run (r/table test-table) conn)) (set pokemons)))
+      (is (= (r/run (-> (r/table test-table) (r/get 25)) conn) (first pokemons)))
+      (is (= (into [] (r/run (-> (r/table test-table) (r/get-all [25 81])) conn)) pokemons))
+      (is (= pokemons (sort-by :national_no (r/run (-> (r/table test-table)
+                                                       (r/between r/minval r/maxval {:right-bound :closed})) conn))))
+      (is (= (r/run (-> (r/table test-table)
+                        (r/between 80 81 {:right-bound :closed})) conn) [(last pokemons)]))
+      (is (= (r/run (-> (r/db test-db)
+                        (r/table test-table)
+                        (r/filter (r/fn [row]
+                                    (r/eq (r/get-field row :name) "Pikachu")))) conn) [(first pokemons)])))))
 
-    (testing "run a query with an implicit database"
-      (with-open [conn (r/connect :db test-db)]
-        (is (= (set (-> (r/table :pokedex) (r/run conn)))
-               (set pokemons))))
-      (testing "precedence of db connections"
-        (with-open [conn (r/connect :db "nonexistent_db")]
-          (is (= (set (-> (r/db test-db) (r/table :pokedex) (r/run conn)))
-                 (set pokemons))))))
+(deftest db-in-connection
+  (testing "run a query with an implicit database"
+    (with-open [conn (r/connect :db test-db)]
+      (is (= [(name test-table)]
+             (-> (r/table-list) (r/run conn))))))
+  (testing "precedence of db connections"
+    (with-open [conn (r/connect :db "nonexistent_db")]
+      (is (= [(name test-table)]
+             (-> (r/db test-db) (r/table-list) (r/run conn)))))))
 
-    (testing "aggregation"
-      (are [term result] (= (run term) result)
-        (r/avg [2 4]) 3
-        (r/min [4 2]) 2
-        (r/max [4 6]) 6
-        (r/sum [3 4]) 7))
+(deftest aggregation
+  (with-open [conn (r/connect)]
+    (are [term result] (= (r/run term conn) result)
+      (r/avg [2 4]) 3
+      (r/min [4 2]) 2
+      (r/max [4 6]) 6
+      (r/sum [3 4]) 7)))
 
-    (testing "feeds"
-      (let [tmp-conn (r/connect :db test-db)
-            changes (future
-                      (-> (r/db test-db)
-                          (r/table :pokedex)
-                          r/changes
-                          (r/run tmp-conn)))]
-        (Thread/sleep 500)
-        (db-run (-> (r/table :pokedex)
-                    (r/insert (take 10000 (repeat {:name "Test"})))))
-        (is (= "Test" ((comp :name :new_val) (first @changes))))
-        (.close tmp-conn)))
+(deftest changefeeds
+  (with-open [conn (r/connect)]
+    (let [changes (future
+                    (-> (r/db test-db)
+                        (r/table test-table)
+                        r/changes
+                        (r/run conn)))]
+      (Thread/sleep 500)
+      (r/run (-> (r/db test-db)
+                 (r/table test-table)
+                 (r/insert (take 2 (repeat {:name "Test"})))) conn)
+      (is (= "Test" ((comp :name :new_val) (first @changes))))))
+  (with-open [conn (r/connect :db test-db)]
+    (let [changes (future
+                    (-> (r/db test-db)
+                        (r/table test-table)
+                        r/changes
+                        (r/run conn)))]
+      (Thread/sleep 500)
+      (r/run (-> (r/table test-table)
+                 (r/insert (take 2 (repeat {:name "Test"}))))
+             conn)
+      (is (= "Test" ((comp :name :new_val) (first @changes)))))))
 
-    (testing "document manipulation"
-      (is (= (db-run (-> (r/table :pokedex)
-                         (r/get 25)
-                         (r/without [:type :name]))) {:national_no 25})))
+(deftest document-manipulation
+  (with-open [conn (r/connect :db test-db)]
+    (r/run (-> (r/table test-table) (r/insert pokemons)) conn)
+    (is (= {:national_no 25}
+           (r/run (-> (r/table test-table)
+                      (r/get 25)
+                      (r/without [:type :name])) conn)))))
 
-    (testing "string manipulating"
-      (are [term result] (= (run term) result)
-        (r/match "pikachu" "^pika")         {:str "pika" :start 0 :groups [] :end 4}
-        (r/split "split this string")       ["split" "this" "string"]
-        (r/split "split,this string" ",")   ["split" "this string"]
-        (r/split "split this string" " " 1) ["split" "this string"]
-        (r/upcase "Shouting")               "SHOUTING"
-        (r/downcase "Whispering")           "whispering"))
+(deftest string-manipulating
+  (with-open [conn (r/connect)]
+    (are [term result] (= (r/run term conn) result)
+      (r/match "pikachu" "^pika") {:str "pika" :start 0 :groups [] :end 4}
+      (r/split "split this string") ["split" "this" "string"]
+      (r/split "split,this string" ",") ["split" "this string"]
+      (r/split "split this string" " " 1) ["split" "this string"]
+      (r/upcase "Shouting") "SHOUTING"
+      (r/downcase "Whispering") "whispering")))
 
-    (testing "dates and times"
-      (are [term result] (= (run term) result)
-        (r/time 2014 12 31)                     (t/date-time 2014 12 31)
-        (r/time 2014 12 31 "+01:00")            (t/from-time-zone
-                                                  (t/date-time 2014 12 31)
-                                                  (t/time-zone-for-offset 1))
-        (r/time 2014 12 31 10 15 30)            (t/date-time 2014 12 31 10 15 30)
-        (r/epoch-time 531360000)                (t/date-time 1986 11 3)
-        (r/iso8601 "2013-01-01T01:01:01+00:00") (t/date-time 2013 01 01 01 01 01)
+(deftest dates-and-times
+  (with-open [conn (r/connect)]
+    (are [term result] (= (r/run term conn) result)
+      (r/time 2014 12 31) (t/date-time 2014 12 31)
+      (r/time 2014 12 31 "+01:00") (t/from-time-zone
+                                     (t/date-time 2014 12 31)
+                                     (t/time-zone-for-offset 1))
+      (r/time 2014 12 31 10 15 30) (t/date-time 2014 12 31 10 15 30)
+      (r/epoch-time 531360000) (t/date-time 1986 11 3)
+      (r/iso8601 "2013-01-01T01:01:01+00:00") (t/date-time 2013 01 01 01 01 01)
+      (r/in-timezone
+        (r/time 2014 12 12) "+02:00") (t/to-time-zone
+                                        (t/date-time 2014 12 12)
+                                        (t/time-zone-for-offset 2))
+      (r/timezone
         (r/in-timezone
-          (r/time 2014 12 12) "+02:00")         (t/to-time-zone
-                                                  (t/date-time 2014 12 12)
-                                                  (t/time-zone-for-offset 2))
-        (r/timezone
-          (r/in-timezone
-            (r/time 2014 12 12) "+02:00"))      "+02:00"
-        (r/during (r/time 2014 12 11)
-                  (r/time 2014 12 10)
-                  (r/time 2014 12 12))          true
-        (r/during (r/time 2014 12 11)
-                  (r/time 2014 12 10)
-                  (r/time 2014 12 11)
-                  {:right-bound :closed})       true
-        (r/date (r/time 2014 12 31 10 15 0))    (t/date-time 2014 12 31)
-        (r/time-of-day
-          (r/time 2014 12 31 10 15 0))          (+ (* 15 60) (* 10 60 60))
-        (r/year (r/time 2014 12 31))            2014
-        (r/month (r/time 2014 12 31))           12
-        (r/day (r/time 2014 12 31))             31
-        (r/day-of-week (r/time 2014 12 31))     3
-        (r/day-of-year (r/time 2014 12 31))     365
-        (r/hours (r/time 2014 12 31 10 4 5))    10
-        (r/minutes (r/time 2014 12 31 10 4 5))  4
-        (r/seconds (r/time 2014 12 31 10 4 5))  5
-        (r/to-iso8601 (r/time 2014 12 31))      "2014-12-31T00:00:00+00:00"
-        (r/to-epoch-time (r/time 1970 1 1))     0))
+          (r/time 2014 12 12) "+02:00")) "+02:00"
+      (r/during (r/time 2014 12 11)
+                (r/time 2014 12 10)
+                (r/time 2014 12 12)) true
+      (r/during (r/time 2014 12 11)
+                (r/time 2014 12 10)
+                (r/time 2014 12 11)
+                {:right-bound :closed}) true
+      (r/date (r/time 2014 12 31 10 15 0)) (t/date-time 2014 12 31)
+      (r/time-of-day
+        (r/time 2014 12 31 10 15 0)) (+ (* 15 60) (* 10 60 60))
+      (r/year (r/time 2014 12 31)) 2014
+      (r/month (r/time 2014 12 31)) 12
+      (r/day (r/time 2014 12 31)) 31
+      (r/day-of-week (r/time 2014 12 31)) 3
+      (r/day-of-year (r/time 2014 12 31)) 365
+      (r/hours (r/time 2014 12 31 10 4 5)) 10
+      (r/minutes (r/time 2014 12 31 10 4 5)) 4
+      (r/seconds (r/time 2014 12 31 10 4 5)) 5
+      (r/to-iso8601 (r/time 2014 12 31)) "2014-12-31T00:00:00+00:00"
+      (r/to-epoch-time (r/time 1970 1 1)) 0)))
 
-    (testing "control structure"
-      (are [term result] (= result (run term))
-        (r/branch true 1 0)                         1
-        (r/branch false 1 0)                        0
-        (r/or false false)                          false
-        (r/any false true)                          true
-        (r/all true true)                           true
-        (r/and true false)                          false
-        (r/coerce-to [["name" "Pikachu"]] "OBJECT") {:name "Pikachu"}
-        (r/type-of [1 2 3])                         "ARRAY"
-        (r/type-of {:number 42})                    "OBJECT"
-        (r/json "{\"number\":42}")                  {:number 42})
-      (is (= (:name (run (r/info (r/db test-db)))) "cljrethinkdb_test")))
+(deftest control-structure
+  (with-open [conn (r/connect)]
+    (are [term result] (= result (r/run term conn))
+      (r/branch true 1 0) 1
+      (r/branch false 1 0) 0
+      (r/or false false) false
+      (r/any false true) true
+      (r/all true true) true
+      (r/and true false) false
+      (r/coerce-to [["name" "Pikachu"]] "OBJECT") {:name "Pikachu"}
+      (r/type-of [1 2 3]) "ARRAY"
+      (r/type-of {:number 42}) "OBJECT"
+      (r/json "{\"number\":42}") {:number 42})))
 
-    (testing "math and logic"
-      (is (< (run (r/random 0 2)) 2))
-      (are [term result] (= (run term) result)
-        (r/add 2 2 2) 6
-        (r/add "Hello " "from " "Tokyo") "Hello from Tokyo"
-        (r/add [1 2] [3 4]) [1 2 3 4]))
+(deftest math-and-logic
+  (with-open [conn (r/connect)]
+    (is (< (r/run (r/random 0 2) conn) 2))
+    (are [term result] (= (r/run term conn) result)
+      (r/add 2 2 2) 6
+      (r/add "Hello " "from " "Tokyo") "Hello from Tokyo"
+      (r/add [1 2] [3 4]) [1 2 3 4])))
 
-    (testing "geospatial commands"
-      (is (= {:type "Point" :coordinates [50 50]}
-             (run (r/geojson {:type "Point" :coordinates [50 50]}))))
-      (is (= "Polygon" (:type (run (r/fill (r/line [[50 51] [51 51] [51 52] [50 51]]))))))
-      (is (= 104644.93094219 (run (r/distance (r/point 20 20)
-                                              (r/circle (r/point 21 20) 2))))))
+(deftest geospatial-commands
+  (with-open [conn (r/connect)]
+    (is (= {:type "Point" :coordinates [50 50]}
+           (r/run (r/geojson {:type "Point" :coordinates [50 50]}) conn)))
+    (is (= "Polygon" (:type (r/run (r/fill (r/line [[50 51] [51 51] [51 52] [50 51]])) conn))))
+    (is (= 104644.93094219 (r/run (r/distance (r/point 20 20)
+                                              (r/circle (r/point 21 20) 2)) conn)))))
 
-    (testing "configuration"
-      (is (= "cljrethinkdb_test" (:name (run (r/config (r/db "cljrethinkdb_test"))))))
-      (is (= "pokedex" (:name (run (-> (r/db "cljrethinkdb_test") (r/table :pokedex) r/config)))))
-      (is (= "pokedex" (:name (db-run (-> (r/table :pokedex)
-                                          r/status))))))
+(deftest configuration
+  (with-open [conn (r/connect)]
+    (is (= "cljrethinkdb_test" (:name (r/run (r/config (r/db test-db)) conn))))
+    (is (= "pokedex" (:name (r/run (-> (r/db test-db) (r/table test-table) r/config) conn))))
+    (is (= "pokedex" (:name (r/run (-> (r/db test-db) (r/table test-table) r/status) conn))))
+    (is (= "cljrethinkdb_test" (:name (r/run (r/info (r/db test-db)) conn))))))
 
-    (testing "nested fns"
-      (is (= [{:a {:foo "bar"}
-               :b [1 2]}]
-             (run (-> [{:foo "bar"}]
+(deftest nested-fns
+  (with-open [conn (r/connect)]
+    (is (= [{:a {:foo "bar"}
+             :b [1 2]}]
+           (r/run (-> [{:foo "bar"}]
                       (r/map (r/fn [x]
                                {:a x
                                 :b (-> [1 2]
                                        (r/map (r/fn [x]
-                                                x)))}))))))
-      (is (= [{:a {:foo "bar"}
-               :b [{:foo "bar"} {:foo "bar"}]}]
-            (run (-> [{:foo "bar"}]
+                                                x)))})))
+                  conn)))
+    (is (= [{:a {:foo "bar"}
+             :b [{:foo "bar"} {:foo "bar"}]}]
+           (r/run (-> [{:foo "bar"}]
                       (r/map (r/fn [x]
                                {:a x
                                 :b (-> [1 2]
                                        (r/map (r/fn [y]
-                                                x)))})))))))
+                                                x)))})))
+                  conn)))))
 
-    (testing "filter with default"
-      (let [twin-peaks [{:name "Cole", :job "Regional Bureau Chief"}
-                        {:name "Cooper", :job "FBI Agent"}
-                        {:name "Riley", :job "Colonel"}
-                        {:name "Briggs", :job "Major"}
-                        {:name "Harry", :job "Sheriff"}
-                        {:name "Hawk", :job "Deputy"}
-                        {:name "Andy", :job "Deputy"}
-                        {:name "Lucy", :job "Secretary"}
-                        {:name "Bobby"}]]
-        (is (= ["Hawk" "Andy" "Bobby"]
-               (run (-> twin-peaks
+(deftest filter-with-default
+  (with-open [conn (r/connect)]
+    (let [twin-peaks [{:name "Cole", :job "Regional Bureau Chief"}
+                      {:name "Cooper", :job "FBI Agent"}
+                      {:name "Riley", :job "Colonel"}
+                      {:name "Briggs", :job "Major"}
+                      {:name "Harry", :job "Sheriff"}
+                      {:name "Hawk", :job "Deputy"}
+                      {:name "Andy", :job "Deputy"}
+                      {:name "Lucy", :job "Secretary"}
+                      {:name "Bobby"}]]
+      (is (= ["Hawk" "Andy" "Bobby"]
+             (r/run (-> twin-peaks
                         (r/filter (r/fn [row]
                                     (r/eq (r/get-field row :job) "Deputy"))
                                   {:default true})
-                        (r/get-field :name)))))
-        (is (thrown?
-             Exception
-             (run (-> twin-peaks
-                      (r/filter (r/fn [row]
-                                  (r/eq (r/get-field row :job) "Deputy"))
-                                {:default (r/error)})
-                      (r/get-field :name)))))
-        (is (= ["Hawk" "Andy"]
-               (run (-> twin-peaks
+                        (r/get-field :name))
+                    conn)))
+      (is (thrown?
+            Exception
+            (r/run (-> twin-peaks
+                       (r/filter (r/fn [row]
+                                   (r/eq (r/get-field row :job) "Deputy"))
+                                 {:default (r/error)})
+                       (r/get-field :name))
+                   conn)))
+      (is (= ["Hawk" "Andy"]
+             (r/run (-> twin-peaks
                         (r/filter (r/fn [row]
                                     (r/eq (r/get-field row :job) "Deputy"))
                                   {:default false})
-                        (r/get-field :name)))))))
-    (.close conn)))
+                        (r/get-field :name))
+                    conn))))))
 
 (deftest query-conn
   (is (do (r/connect)
           true)))
 
-(use-fixtures :once setup)
+(use-fixtures :each setup-each)
+(use-fixtures :once setup-once)

--- a/test/rethinkdb/core_test.clj
+++ b/test/rethinkdb/core_test.clj
@@ -56,10 +56,11 @@
   (with-open [conn (r/connect :db test-db)]
     (are [term result] (contains? (set (split-map (r/run term conn))) result)
       (r/table-create (r/db test-db) :tmp) {:tables_created 1}
+      (r/table-create (r/db test-db) :tmp2) {:tables_created 1}
       (-> (r/table :tmp)
           (r/insert {:id (java.util.UUID/randomUUID)})) {:inserted 1}
-      (r/table-drop :tmp) {:tables_dropped 1}
-
+      (r/table-drop (r/db test-db) :tmp) {:tables_dropped 1}
+      (r/table-drop :tmp2) {:tables_dropped 1}
       (-> (r/table test-table) (r/index-create :tmp (r/fn [row] 1))) {:created 1}
       (-> (r/table test-table)
           (r/index-create :type (r/fn [row]


### PR DESCRIPTION
This change makes it easier to isolate failing tests and to create new tests.
 - Split the one large deftest into many smaller deftests
 - Add fixtures to recreate pokedex table between every test
 - Remove `run` and `db-run` command from core-test ns
 - Remove global `conn`, each test now creates its own connection

Add arity for table and db operations without DB, the new arities will use the implicit DB from the connection.
 - Add documentation for database priority to ns docstring
 - Update docstrings on functions to reference priority docs in ns docstring

Arities modified on
 - table-drop
 - table-list

table-create was left as I wasn't yet sure how to handle the optargs with two arities.