### PR TITLE
Core async channel API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file. This change
 - Add docstring for `rethinkdb.core/close`. [#44](https://github.com/apa512/clj-rethinkdb/pull/44)
 - Add alias for `rethinkdb.core/connect` into `rethinkdb.query/connect` so you don't need to import the `rethinkdb.core` namespace. [#44](https://github.com/apa512/clj-rethinkdb/pull/44)
 - Add CHANGELOG.md [#47](https://github.com/apa512/clj-rethinkdb/pull/47)
+- Add core.async channel API for executing queries [#37](https://github.com/apa512/clj-rethinkdb/pull/37)
 - Added explicit support for RethinkDB 2.0 (It worked before but wasn't documented as such).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,13 @@ All notable changes to this project will be documented in this file. This change
 - Update arity and docstring for `rethinkdb.query/merge` to support merging any number of objects.
 - Add new arity to `rethinkdb.query/index-create` to allow creating simple indexes from field names. [#86](https://github.com/apa512/clj-rethinkdb/pull/86)
 - Update `rethinkdb.query/time` arity to only allow 3, 4, 6, and 7 arguments. Also update docstring to make usage clearer. This was already enforced on the server, but will now be enforced by the client library too. [#87](https://github.com/apa512/clj-rethinkdb/issues/87)
+- Add core.async channel API for executing queries [#37](https://github.com/apa512/clj-rethinkdb/pull/37)
 
 ## [0.10.1] - 2015-07-08
 ### Added
 - Add docstring for `rethinkdb.core/close`. [#44](https://github.com/apa512/clj-rethinkdb/pull/44)
 - Add alias for `rethinkdb.core/connect` into `rethinkdb.query/connect` so you don't need to import the `rethinkdb.core` namespace. [#44](https://github.com/apa512/clj-rethinkdb/pull/44)
 - Add CHANGELOG.md [#47](https://github.com/apa512/clj-rethinkdb/pull/47)
-- Add core.async channel API for executing queries [#37](https://github.com/apa512/clj-rethinkdb/pull/37)
 - Added explicit support for RethinkDB 2.0 (It worked before but wasn't documented as such).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com).
 
 ## [Unreleased]
+### Changed
+- Disable Nagle's algorithm (set TCP NO_DELAY to true). This provides a speedup of around 30-40x for small queries on Linux. [#114](https://github.com/apa512/clj-rethinkdb/pull/114)
+- Added a new arity to `changes` that allows you to pass optargs. [#112](https://github.com/apa512/clj-rethinkdb/issues/112)
+- Renamed changes arg from `table` to `xs`. [#76](https://github.com/apa512/clj-rethinkdb/issues/76)
+
+
+## [0.11.0] - 2015-10-19
 ### Added
 - clojure.tools.logging support. [#72](https://github.com/apa512/clj-rethinkdb/pull/72)
 - `fn` macro to ClojureScript `rethinkdb.query` namespace. [#64](https://github.com/apa512/clj-rethinkdb/issues/64)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # clj-rethinkdb
 
-A RethinkDB client for Clojure. Tested and supported on RethinkDB 2.0.x but should with work all versions that support the JSON protocol (i.e. >= 1.13).
+A RethinkDB client for Clojure. Tested and supported on RethinkDB 2.0.x, it uses the v4 protocol introduced in RethinkDB 2.0, so it won't work on older versions. clj-rethinkdb 0.10.x supports back to RethinkDB 0.13.
 
 [![Circle CI](https://circleci.com/gh/apa512/clj-rethinkdb.svg?style=svg)](https://circleci.com/gh/apa512/clj-rethinkdb)
 [![Dependencies Status](http://jarkeeper.com/apa512/clj-rethinkdb/status.svg)](http://jarkeeper.com/apa512/clj-rethinkdb)

--- a/src/rethinkdb/core.clj
+++ b/src/rethinkdb/core.clj
@@ -13,7 +13,7 @@
         v2 1915781601
         v3 1601562686
         v4 1074539808]
-    (send-int out v3 4)))
+    (send-int out v4 4)))
 
 (defn send-protocol
   "Sends protocol type to RethinkDB when establishing connection.

--- a/src/rethinkdb/core.clj
+++ b/src/rethinkdb/core.clj
@@ -41,7 +41,7 @@
       (if chanset
         (async/>!! (:control-in-chan chanset) :stop))
         (send-stop-query conn token))
-    (Thread/sleep 500) ;; Gross
+    (Thread/sleep 500) ;; FIXME: Gross
     #_(doseq [[token chanset] waiting
             :when (some? chanset)] ;; TODO, take first cab off rank, not process tokens in serial.
       (async/alt!!

--- a/src/rethinkdb/net.clj
+++ b/src/rethinkdb/net.clj
@@ -20,9 +20,8 @@
   Closeable
   (close [this] (and (send-stop-query conn token) :closed))
   clojure.lang.Seqable
-  (seq [this] (do
-                (Thread/sleep 250)
-                (lazy-seq (concat coll (send-continue-query conn token))))))
+  (seq [this]
+    (lazy-seq (concat coll (send-continue-query conn token)))))
 
 (defn send-int [^OutputStream out i n]
   (.write out (int->bytes i n) 0 n))

--- a/src/rethinkdb/net.clj
+++ b/src/rethinkdb/net.clj
@@ -192,6 +192,7 @@
                     ;; Recur with a continue query, same token will be used.
                     (recur (qb/prepare-query :CONTINUE)))
               ;; else an error occurred
-              (do (async/>! error-chan parsed-resp)
-                  (clean-up :error)))))))
+              (let [ex (ex-info (str (first resp)) msg)]
+                (async/>! error-chan ex)
+                (clean-up :error)))))))
     chan-set))

--- a/src/rethinkdb/net.clj
+++ b/src/rethinkdb/net.clj
@@ -5,7 +5,7 @@
             [rethinkdb.query-builder :refer [parse-query]]
             [rethinkdb.types :as types]
             [rethinkdb.response :refer [parse-response]]
-            [rethinkdb.utils :refer [str->bytes int->bytes bytes->int pp-bytes]]
+            [rethinkdb.utils :as utils :refer [str->bytes int->bytes bytes->int pp-bytes]]
             [rethinkdb.query-builder :as qb])
   (:import [java.io Closeable InputStream OutputStream DataInputStream]))
 
@@ -91,11 +91,11 @@
     ;; Close recv channel
     (async/close! recv-chan)))
 
-(defn add-to-waiting [conn token]
-  (swap! (:conn conn) update-in [:waiting] (fn [waiting-set] (conj waiting-set token))))
+(defn add-to-waiting [conn token chan-set]
+  (swap! (:conn conn) assoc-in [:waiting token] chan-set))
 
 (defn remove-from-waiting [conn token]
-  (swap! (:conn conn) update-in [:waiting] (fn [waiting-set] (disj waiting-set token))))
+  (swap! (:conn conn) utils/dissoc-in [:waiting token]))
 
 ;; Sync
 
@@ -126,7 +126,7 @@
       #{3 5} (if (get (:waiting @conn) token) ;; Success Partial, Query returned a partial sequence of RQL datatypes.
                (lazy-seq (concat resp (send-continue-query conn token)))
                (do
-                 (add-to-waiting conn token)
+                 (add-to-waiting conn token nil)
                  (Cursor. conn token resp)))
       (let [ex (ex-info (str (first resp)) json-resp)]
         (log/error ex)
@@ -151,41 +151,47 @@
         token (:token (swap! (:conn conn) update-in [:token] inc))
         global-optargs (when db [{:db [(types/tt->int :DB) [db]]}])
         payload (qb/prepare-query :START query global-optargs)
-        control-chan (async/chan 10)
+        control-in-chan (async/chan 10)
+        control-out-chan (async/chan 10)
         error-chan (async/chan 10)
-        chan-set {:result-chan result-chan :error-chan error-chan :control-chan control-chan :token token}
+        chan-set {:result-chan result-chan :error-chan error-chan :control-in-chan control-in-chan :control-out-chan control-out-chan :token token}
         pub-resp-chan (async/chan) ;; Internal channel for receiving RethinkDB responses for this query's token.
         {:keys [pub send-chan]} @conn
-        _ (add-to-waiting conn token)]
+        _ (add-to-waiting conn token chan-set)
+        clean-up (fn [close-type]
+                   (async/>!! control-out-chan close-type)
+                   (utils/close-chans [result-chan error-chan control-in-chan])
+                   (remove-from-waiting conn token))]
     (async/go-loop [payload payload]
       (async/sub pub token pub-resp-chan) ;; Subscribe to connection publication channel for our query token
       (async/>! send-chan [token payload])
       (async/alt!
         :priority true
-        control-chan ([ctrl-value] (do (async/close! result-chan) ;;TODO: Is ordering correct here?
-                                       (async/close! error-chan)
-                                       (async/>! send-chan [token (qb/prepare-query :STOP)])
-                                       (async/<! pub-resp-chan)
-                                       (remove-from-waiting conn token)))
-        pub-resp-chan ([resp] (let [[recvd-token json] resp ;; TODO: use Transducers for this section
-                                    _ (assert (= recvd-token token)
-                                              "Must not receive response for different token") ;;TODO: Is this really necessary with the async/sub?
-                                    _ (async/unsub pub token pub-resp-chan)
-                                    {type :t resp :r :as msg} (json/read-str json :key-fn keyword)
-                                    parsed-resp {:type type :resp (parse-response resp)}]
-                                (println msg)
-                                (case (int type)
-                                  ;; 1 is a single result, 2 is a result sequence.
-                                  (1 2) (do (async/>! result-chan parsed-resp)
-                                            (async/close! result-chan)
-                                            (remove-from-waiting conn token))
-                                  ;; 3 is a partial sequence.
-                                  3 (do (async/>! result-chan parsed-resp)
-                                        ;; Recur with a continue query, same token will be used
-                                        (recur (qb/prepare-query :CONTINUE)))
-                                  ;; else an error occurred
-                                  (do (async/>! error-chan parsed-resp)
-                                      (async/close! error-chan)))))
 
-        ))
+        control-in-chan
+        ([ctrl-value]
+          (do ;; Can't close channel, see http://dev.clojure.org/jira/browse/ASYNC-135, need another way to express this pattern
+            #_(async/close! control-in-chan) ;; Shut the door on the way out, don't want to send a STOP query twice.
+            (recur (qb/prepare-query :STOP))))
+
+        pub-resp-chan
+        ([resp]
+          (let [[recvd-token json] resp ;; TODO: use Transducers for this section
+                _ (assert (= recvd-token token)
+                          "Must not receive response for different token") ;;TODO: Is this really necessary with the async/sub?
+                _ (async/unsub pub token pub-resp-chan)
+                {type :t resp :r :as msg} (json/read-str json :key-fn keyword)
+                parsed-resp (parse-response resp)]
+            (case (int type)
+              ;; 1 is a single result, 2 is a result sequence. However they are both wrapped in a vector
+              ;; so onto-chan works correctly for both.
+              (1 2) (do (async/onto-chan result-chan parsed-resp true)
+                        (clean-up :closed))
+              ;; 3 is a partial sequence.
+              3 (do (async/onto-chan result-chan parsed-resp false)
+                    ;; Recur with a continue query, same token will be used.
+                    (recur (qb/prepare-query :CONTINUE)))
+              ;; else an error occurred
+              (do (async/>! error-chan parsed-resp)
+                  (clean-up :error)))))))
     chan-set))

--- a/src/rethinkdb/net.clj
+++ b/src/rethinkdb/net.clj
@@ -168,7 +168,8 @@
                                   #{1 2} (do (async/onto-chan result-chan resp true) ;; 1 is a single result, 2 is a result sequence.
                                              (remove-from-waiting conn token))
                                   #{3} (do (async/onto-chan result-chan resp false) ;; 3 is a partial sequence.
-                                           (recur (qb/prepare-query :CONTINUE))))))
+                                           (recur (qb/prepare-query :CONTINUE)))
+                                  (async/onto-chan error-chan resp true))))
         control-chan ([ctrl-value] (do (async/close! result-chan) ;;TODO: Is ordering correct here?
                                        (async/close! error-chan)
                                        (async/>! send-chan [token (qb/prepare-query :STOP)])

--- a/src/rethinkdb/net.clj
+++ b/src/rethinkdb/net.clj
@@ -170,7 +170,7 @@
 
         control-in-chan
         ([ctrl-value]
-          (do ;; Can't close channel, see http://dev.clojure.org/jira/browse/ASYNC-135, need another way to express this pattern
+          (do ;; Can't close channel, as we'll always alt! onto the closed channel. Need another way to express this pattern.
             #_(async/close! control-in-chan) ;; Shut the door on the way out, don't want to send a STOP query twice.
             (recur (qb/prepare-query :STOP))))
 
@@ -188,7 +188,7 @@
               (1 2) (do (async/<! (async/onto-chan result-chan parsed-resp true)) ;; Need to wait for all values to go onto chan before closing
                         (clean-up :closed))
               ;; 3 is a partial sequence.
-              3 (do (async/onto-chan result-chan parsed-resp false)
+              3 (do (async/<! (async/onto-chan result-chan parsed-resp false)) ;; Need to wait for all values to go onto chan before recurring to preserve backpressure
                     ;; Recur with a continue query, same token will be used.
                     (recur (qb/prepare-query :CONTINUE)))
               ;; else an error occurred

--- a/src/rethinkdb/net.clj
+++ b/src/rethinkdb/net.clj
@@ -186,7 +186,7 @@
           (let [[recvd-token json] resp ;; TODO: use Transducers for this section
                 _ (assert (= recvd-token token)
                           (format "Must not receive response for different token %d != %d" recvd-token token)) ;;TODO: Is this really necessary with the async/sub?
-                _ (async/unsub pub token pub-resp-chan)
+                _ (async/unsub-all pub token)
                 {type :t resp :r :as msg} (json/read-str json :key-fn keyword)
                 parsed-resp (parse-response resp)]
             (log/debugf "Parsed type: %s response: %s" type parsed-resp)

--- a/src/rethinkdb/net.clj
+++ b/src/rethinkdb/net.clj
@@ -147,8 +147,10 @@
 ;; Async
 
 (defn run-query-chan [query conn result-chan]
-  (let [token (:token (swap! (:conn conn) update-in [:token] inc))
-        payload (qb/prepare-query :START query)
+  (let [{:keys [db]} @conn
+        token (:token (swap! (:conn conn) update-in [:token] inc))
+        global-optargs (when db [{:db [(types/tt->int :DB) [db]]}])
+        payload (qb/prepare-query :START query global-optargs)
         control-chan (async/chan 10)
         error-chan (async/chan 10)
         chan-set {:result-chan result-chan :error-chan error-chan :control-chan control-chan :token token}

--- a/src/rethinkdb/net.clj
+++ b/src/rethinkdb/net.clj
@@ -21,8 +21,9 @@
   Closeable
   (close [this] (and (send-stop-query conn token) :closed))
   clojure.lang.Seqable
-  (seq [this]
-    (lazy-seq (concat coll (send-continue-query conn token)))))
+  (seq [this] (do
+                (Thread/sleep 250)
+                (lazy-seq (concat coll (send-continue-query conn token))))))
 
 (defn send-int [^OutputStream out i n]
   (.write out (int->bytes i n) 0 n))

--- a/src/rethinkdb/net.clj
+++ b/src/rethinkdb/net.clj
@@ -160,7 +160,7 @@
         _ (add-to-waiting conn token chan-set)
         clean-up (fn [close-type]
                    (async/>!! control-out-chan close-type)
-                   (utils/close-chans [result-chan error-chan control-in-chan])
+                   (utils/close-chans [result-chan error-chan control-in-chan]) ;; TODO: close control-out-chan too?
                    (remove-from-waiting conn token))]
     (async/go-loop [payload payload]
       (async/sub pub token pub-resp-chan) ;; Subscribe to connection publication channel for our query token

--- a/src/rethinkdb/net.clj
+++ b/src/rethinkdb/net.clj
@@ -151,7 +151,7 @@
         payload (qb/prepare-query :START query)
         control-chan (async/chan 10)
         error-chan (async/chan 10)
-        chan-set {:result-chan result-chan :error-chan error-chan :control-chan control-chan}
+        chan-set {:result-chan result-chan :error-chan error-chan :control-chan control-chan :token token}
         pub-resp-chan (async/chan) ;; Internal channel for receiving RethinkDB responses for this query's token.
         {:keys [pub send-chan]} @conn
         _ (add-to-waiting conn token)]

--- a/src/rethinkdb/net.clj
+++ b/src/rethinkdb/net.clj
@@ -185,7 +185,7 @@
             (case (int type)
               ;; 1 is a single result, 2 is a result sequence. However they are both wrapped in a vector
               ;; so onto-chan works correctly for both.
-              (1 2) (do (async/onto-chan result-chan parsed-resp true)
+              (1 2) (do (async/<! (async/onto-chan result-chan parsed-resp true)) ;; Need to wait for all values to go onto chan before closing
                         (clean-up :closed))
               ;; 3 is a partial sequence.
               3 (do (async/onto-chan result-chan parsed-resp false)

--- a/src/rethinkdb/query.cljc
+++ b/src/rethinkdb/query.cljc
@@ -1004,3 +1004,6 @@
 #?(:clj (defn run [query conn]
           (let [token (:token (swap! (:conn conn) update-in [:token] inc))]
             (net/send-start-query conn token (replace-vars query)))))
+
+(defn run-chan [query conn result-chan]
+  (net/run-query-chan query conn result-chan))

--- a/src/rethinkdb/query.cljc
+++ b/src/rethinkdb/query.cljc
@@ -987,9 +987,10 @@
           (let [token (:token (swap! (:conn conn) update-in [:token] inc))]
             (net/send-start-query conn token (qb/replace-vars query)))))
 
-(defn run-chan
-  "Runs query on conn and puts results on result-chan. Returns a map of channels and the query token
-  {:result-chan <> :error-chan <> :control-chan <> :token <>}. Results will be put on result-chan,
-  errors will be put on error-chan, queries can be stopped by putting :STOP on control-chan"
-  [query conn result-chan]
-  (net/run-query-chan query conn result-chan))
+#?(:clj (defn run-chan
+          "Runs query on conn and puts results on result-chan. Returns a map of channels and the query token
+          {:result-chan <> :error-chan <> :control-in-chan <> :control-out-chan <> :token <>}.
+          Results will be put on result-chan, errors will be put on error-chan, queries can be stopped
+          by putting :stop on control-in-chan"
+          [query conn result-chan]
+          (net/run-query-chan query conn result-chan)))

--- a/src/rethinkdb/query.cljc
+++ b/src/rethinkdb/query.cljc
@@ -44,12 +44,13 @@
 
 #?(:clj (def ^Connection connect
           "Creates a database connection to a RethinkDB host
-          [& {:keys [host port token auth-key db]
+          [& {:keys [host port token auth-key db close-timeout-ms]
                :or {host \"127.0.0.1\"
                     port 28015
                     token 0
                     auth-key \"\"
-                    db nil}}" core/connect))
+                    db nil
+                    close-timeout-ms 5000}}" core/connect))
 
 ;;; Cursors
 
@@ -77,8 +78,10 @@
 
 (defn table-create
   "Create a table."
-  [db table-name & [optargs]]
-  (term :TABLE_CREATE [db table-name] optargs))
+  ([table-name]
+    (term :TABLE_CREATE [table-name]))
+  ([db table-name & [optargs]]
+   (term :TABLE_CREATE [db table-name] optargs)))
 
 (defn table-drop
   "Drop a table. If no db is provided then precedence follows the
@@ -994,4 +997,4 @@
           Results will be put on result-chan, errors will be put on error-chan, queries can be stopped
           by putting :stop on control-in-chan"
           [query conn result-chan]
-          (net/run-query-chan query conn result-chan)))
+          (net/send-query-chan query conn result-chan)))

--- a/src/rethinkdb/query.cljc
+++ b/src/rethinkdb/query.cljc
@@ -980,30 +980,12 @@
 
 ;;; Run query
 
-(defn replace-vars [query]
-  (let [var-counter (atom 0)]
-    (walk/postwalk
-      #(if (clojure.core/and (map? %) (= :FUNC (:rethinkdb.query-builder/term %)))
-        (let [vars (first (:rethinkdb.query-builder/args %))
-              new-vars (range @var-counter (+ @var-counter (clojure.core/count vars)))
-              new-args (clojure.core/map
-                         (clojure.core/fn [arg]
-                           (term :VAR [arg]))
-                         new-vars)
-              var-replacements (zipmap vars new-args)]
-          (swap! var-counter + (clojure.core/count vars))
-          (walk/postwalk-replace
-            var-replacements
-            (assoc-in % [:rethinkdb.query-builder/args 0] new-vars)))
-        %)
-      query)))
-
 (defn make-array [& xs]
   (term :MAKE_ARRAY xs))
 
 #?(:clj (defn run [query conn]
           (let [token (:token (swap! (:conn conn) update-in [:token] inc))]
-            (net/send-start-query conn token (replace-vars query)))))
+            (net/send-start-query conn token (qb/replace-vars query)))))
 
 (defn run-chan
   "Runs query on conn and puts results on result-chan. Returns a map of channels and the query token

--- a/src/rethinkdb/query.cljc
+++ b/src/rethinkdb/query.cljc
@@ -17,7 +17,8 @@
             [rethinkdb.query-builder :as qb :refer [term]]
     #?@(:clj [
             [rethinkdb.net :as net]
-            [rethinkdb.core :as core]]))
+            [rethinkdb.core :as core]
+            [clojure.core.async :as async]]))
   #?(:clj
      (:import [rethinkdb.core Connection])))
 

--- a/src/rethinkdb/query.cljc
+++ b/src/rethinkdb/query.cljc
@@ -139,10 +139,12 @@
   (term :INDEX_WAIT (concat [table] index-names)))
 
 (defn changes
-  "Return an infinite stream of objects representing changes to a table or a
-  document."
-  [table]
-  (term :CHANGES [table]))
+  "Return an infinite stream of objects representing changes to a table, sequence,
+   or a document."
+  ([xs]
+   (term :CHANGES [xs]))
+  ([xs optargs]
+   (term :CHANGES [xs] optargs)))
 
 ;;; Writing data
 

--- a/src/rethinkdb/query.cljc
+++ b/src/rethinkdb/query.cljc
@@ -1005,5 +1005,9 @@
           (let [token (:token (swap! (:conn conn) update-in [:token] inc))]
             (net/send-start-query conn token (replace-vars query)))))
 
-(defn run-chan [query conn result-chan]
+(defn run-chan
+  "Runs query on conn and puts results on result-chan. Returns a map of channels and the query token
+  {:result-chan <> :error-chan <> :control-chan <> :token <>}. Results will be put on result-chan,
+  errors will be put on error-chan, queries can be stopped by putting :STOP on control-chan"
+  [query conn result-chan]
   (net/run-query-chan query conn result-chan))

--- a/src/rethinkdb/query_builder.cljc
+++ b/src/rethinkdb/query_builder.cljc
@@ -77,17 +77,17 @@
         %)
       query)))
 
-(defn prepare-query
-  "If only type is provided, then the query is assumed to be a
-  :STOP or :CONTINUE query. global-optargs may be nil."
-  ([type]
-   (->> (parse-query type)
-        (json/write-str)))
-  ([type term]
-   (prepare-query type term nil))
-  ([type term global-optargs]
-   (as-> term $
-         (replace-vars $)
-         (parse-query type $)
-         (concat $ global-optargs)
-         (json/write-str $))))
+#?(:clj (defn prepare-query
+          "If only type is provided, then the query is assumed to be a
+          :STOP or :CONTINUE query. global-optargs may be nil."
+          ([type]
+           (->> (parse-query type)
+                (json/write-str)))
+          ([type term]
+           (prepare-query type term nil))
+          ([type term global-optargs]
+           (as-> term $
+                 (replace-vars $)
+                 (parse-query type $)
+                 (concat $ global-optargs)
+                 (json/write-str $)))))

--- a/src/rethinkdb/query_builder.cljc
+++ b/src/rethinkdb/query_builder.cljc
@@ -1,7 +1,9 @@
 (ns rethinkdb.query-builder
   (:require [rethinkdb.utils :refer [snake-case]]
+            [clojure.walk :as walk]
             [rethinkdb.types :refer [tt->int qt->int]]
     #?@(:clj [
+            [clojure.data.json :as json]
             [clj-time.coerce :as c]])))
 
 (defn term [term args & [optargs]]
@@ -56,3 +58,36 @@
    [(qt->int type)])
   ([type term]
    [(qt->int type) (parse-term term)]))
+
+(defn replace-vars [query]
+  (let [var-counter (atom 0)]
+    (walk/postwalk
+      #(if (clojure.core/and (map? %) (= :FUNC (:rethinkdb.query-builder/term %)))
+        (let [vars (first (:rethinkdb.query-builder/args %))
+              new-vars (range @var-counter (+ @var-counter (clojure.core/count vars)))
+              new-args (clojure.core/map
+                         (clojure.core/fn [arg]
+                           (term :VAR [arg]))
+                         new-vars)
+              var-replacements (zipmap vars new-args)]
+          (swap! var-counter + (clojure.core/count vars))
+          (walk/postwalk-replace
+            var-replacements
+            (assoc-in % [:rethinkdb.query-builder/args 0] new-vars)))
+        %)
+      query)))
+
+(defn prepare-query
+  "If only type is provided, then the query is assumed to be a
+  :STOP or :CONTINUE query. global-optargs may be nil."
+  ([type]
+   (->> (parse-query type)
+        (json/write-str)))
+  ([type term]
+   (prepare-query type term nil))
+  ([type term global-optargs]
+   (as-> term $
+         (replace-vars $)
+         (parse-query type $)
+         (concat $ global-optargs)
+         (json/write-str $))))

--- a/test-resources/logback-test.xml
+++ b/test-resources/logback-test.xml
@@ -4,12 +4,13 @@
         <!-- encoders are assigned the type
              ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
-            <pattern>%highlight(%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36}) - %msg%n</pattern>
+            <pattern>%highlight(%d{HH:mm:ss.SSS} %-5level %logger{36}) - %msg%n</pattern>
         </encoder>
     </appender>
 
-    <root level="ERROR">
+    <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>
-    <logger name="rethinkdb.net" level="INFO"/>
+    <logger name="rethinkdb.net" level="TRACE"/>
+    <logger name="rethinkdb.core" level="DEBUG"/>
 </configuration>

--- a/test/rethinkdb/connection_test.clj
+++ b/test/rethinkdb/connection_test.clj
@@ -1,7 +1,9 @@
 (ns rethinkdb.connection-test
-  (:require [clj-time.core :as t]
-            [clojure.test :refer :all]
-            [rethinkdb.query :as r]))
+  (:require [clojure.test :refer :all]
+            [rethinkdb.query :as r]
+            [clojure.core.async :as async]
+            [rethinkdb.test-util :as tutil])
+  (:import (java.util.concurrent TimeoutException)))
 
 ;;; Reference performance
 ;; performance (connect)          "Elapsed time: 4021.701763 msecs"
@@ -15,42 +17,41 @@
      ~expr
      (/ (double (- (. System (nanoTime)) start#)) 1000000.0)))
 
-(def test-db "cljrethinkdb_test")
+(def test-db tutil/test-db)
+(def test-table tutil/test-table)
+(def changes-query (r/changes (r/table test-table)))
+(def table-list (-> (r/db test-db) (r/table-list)))
 
-(defn setup [test-fn]
+(defn setup-each [test-fn]
+  (with-open [conn (r/connect :db test-db)]
+    (tutil/ensure-table test-db (name test-table) {:primary-key :national_no} conn))
+  (test-fn))
+
+(defn setup-once [test-fn]
   (with-open [conn (r/connect)]
-    (if (some #{test-db} (r/run (r/db-list) conn))
-      (r/run (r/db-drop test-db) conn))
-    (r/run (r/db-create test-db) conn)
-    (test-fn)))
-
-(use-fixtures :once setup)
-
-(def query
-  (-> (r/db test-db)
-      (r/table-list)))
-
+    (tutil/ensure-db test-db conn))
+  (test-fn))
 
 ;; Uncomment to run test
-(deftest connection-speed-test
+#_(deftest connection-speed-test
   (println "performance (connection per query)")
   (let [conn r/connect]
     (time
       (doseq [n (range 100)]
         (with-open [conn (r/connect)]
-          (r/run query conn)))))
+          (r/run table-list conn)))))
 
   (println "performance (reusing connection")
   (time
     (with-open [conn (r/connect)]
       (doseq [n (range 100)]
-        (r/run query conn))))
+        (r/run table-list conn))))
 
   (println "performance (parallel, one connection)")
   (with-open [conn (r/connect)]
     (time
       (doall
-        (pmap (fn [v] (r/run query conn))
+        (pmap (fn [v] (r/run table-list conn))
               (range 100)))))
 
   (println "performance (pooled connection")
@@ -61,16 +62,72 @@
   (let [conn1 (r/connect)
         conn2 (r/connect)
         conn3 (r/connect)]
-    (r/run query conn1)
+    (r/run table-list conn1)
     (future
       (do
-        (r/run query conn2)
+        (r/run table-list conn2)
         (.close conn1)))
     (future
       (with-open [conn (r/connect)]
-        (r/run query conn)))
+        (r/run table-list conn)))
     (future
       (.close conn2))
-    (r/run query conn3)
+    (r/run table-list conn3)
     (.close conn3)
     (is true)))
+
+(defn run-changefeed
+  "Returns the value from calling run-chan n times. Use dotimes if you don't
+  need return results. Lazy."
+  [n conn]
+  (repeatedly n #(r/run-chan changes-query conn (async/chan))))
+
+(deftest close-conn-sync-query-test
+  (let [conn (r/connect :db test-db)]
+    (dotimes [n 100] (r/run changes-query conn))
+    (is (nil? (.close conn)))
+    (is (empty? (:waiting @conn)))))
+
+(deftest close-conn-chan-query-test
+  (let [conn (r/connect :db test-db)
+        chans (doall (map :out-ch (run-changefeed 50 conn)))]
+    (is (nil? (.close conn)))
+    (is (empty? (:waiting @conn)))
+    (is (nil? (tutil/altout (async/merge chans))))))
+
+(deftest close-conn-mixed-test
+  (let [conn (r/connect :db test-db)
+        chans (doall (map :out-ch (run-changefeed 50 conn)))]
+    (dotimes [n 50] (r/run-chan changes-query conn (async/chan 1)))
+    (dotimes [n 50] (r/run changes-query conn))
+    (dotimes [n 50] (r/run-chan changes-query conn (async/chan 1)))
+    (is (nil? (.close conn)))
+    (is (empty? (:waiting @conn)))
+    (is (nil? (tutil/altout (async/merge chans))))))
+
+(deftest timeout-throw-test
+  (let [conn (r/connect :db test-db :close-timeout-ms 0)]
+    (dotimes [n 100] (r/run-chan changes-query conn (async/chan 1)))
+    (is (thrown-with-msg? TimeoutException
+                          #"Timed out after 0 ms waiting for a close response for all queries from RethinkDB. 100 queries were force closed."
+                          (.close conn)))
+    (is (empty? (:waiting @conn)))))
+
+(deftest close-changefeed-test
+  (with-open [conn (r/connect :db test-db)]
+    (let [stop-fns (doall (map :stop-fn (run-changefeed 50 conn)))]
+      (is (= 50 (count (:waiting @conn))))
+      (is (every? nil? (map (fn [f] (f)) stop-fns)))
+      (is (zero? (count (:waiting @conn)))))))
+
+(deftest close-changefeed-timeout-test
+  (let [conn (r/connect :db test-db)
+        stop-fn (:stop-fn (first (run-changefeed 1 conn)))]
+    (is (thrown-with-msg? TimeoutException
+                         #"Timed out after 0 ms waiting for RethinkDB to respond to close query request. Query was force closed."
+                         (stop-fn 0)))
+    (is (empty? (:waiting @conn)))
+    (.close conn)))
+
+(use-fixtures :each setup-each)
+(use-fixtures :once setup-once)

--- a/test/rethinkdb/core_test.clj
+++ b/test/rethinkdb/core_test.clj
@@ -372,7 +372,7 @@
   (with-open [conn (r/connect :db test-db)]
 
     (let [[resp success?] (test-query-chan (r/db-drop "cljrethinkdb_nonexistentdb") conn)]
-      (is (= ["Database `cljrethinkdb_nonexistentdb` does not exist."] resp))
+      (is (= "Database `cljrethinkdb_nonexistentdb` does not exist." (.getMessage resp)))
       (is (not success?)))
 
     (let [[resp success?] (test-query-chan (r/db-list) conn)]

--- a/test/rethinkdb/core_test.clj
+++ b/test/rethinkdb/core_test.clj
@@ -169,28 +169,28 @@
       (r/sum [3 4]) 7)))
 
 (deftest changefeeds
-    (with-open [conn (r/connect)]
-      (let [changes (future
-                      (-> (r/db test-db)
-                          (r/table test-table)
-                          r/changes
-                          (r/run conn)))]
-        (Thread/sleep 500)
-        (r/run (-> (r/db test-db)
-                   (r/table test-table)
-                   (r/insert (take 2 (repeat {:name "Test"})))) conn)
-        (is (= "Test" ((comp :name :new_val) (first @changes))))))
-    (with-open [conn (r/connect :db test-db)]
-      (let [changes (future
-                      (-> (r/db test-db)
-                          (r/table test-table)
-                          r/changes
-                          (r/run conn)))]
-        (Thread/sleep 500)
-        (r/run (-> (r/table test-table)
-                   (r/insert (take 2 (repeat {:name "Test"}))))
-               conn)
-        (is (= "Test" ((comp :name :new_val) (first @changes)))))))
+  (with-open [conn (r/connect)]
+    (let [changes (future
+                    (-> (r/db test-db)
+                        (r/table test-table)
+                        r/changes
+                        (r/run conn)))]
+      (Thread/sleep 500)
+      (r/run (-> (r/db test-db)
+                 (r/table test-table)
+                 (r/insert (take 2 (repeat {:name "Test"})))) conn)
+      (is (= "Test" (get-in (first @changes) [:new_val :name])))))
+  (with-open [conn (r/connect :db test-db)]
+    (let [changes (future
+                    (-> (r/db test-db)
+                        (r/table test-table)
+                        (r/changes {:include-states true})
+                        (r/run conn)))]
+      (Thread/sleep 500)
+      (r/run (-> (r/table test-table)
+                 (r/insert (take 2 (repeat {:name "Test"}))))
+             conn)
+      (is (= {:state "ready"} (first @changes))))))
 
 (deftest document-manipulation
   (with-open [conn (r/connect :db test-db)]

--- a/test/rethinkdb/core_test.clj
+++ b/test/rethinkdb/core_test.clj
@@ -360,19 +360,13 @@
                         (r/get-field :name))
                     conn))))))
 
-(defn test-query-chan-raw
-  "Executes query on conn. Returns the first raw result from the connection either from the
-  result channel or error channel, and whether the query was successful."
+(defn test-query-chan
+  "Executes query on conn. Returns a vector of the first raw result from the connection
+   from either the result or error channel, and whether the query was successful."
   [query conn]
   (let [{:keys [error-chan result-chan]} (r/run-chan query conn (async/chan 10))
         [v p] (async/alts!! [error-chan result-chan] :priority true)]
     [v (= p result-chan)]))
-
-(defn test-query-chan
-  "Like test-query-chan-raw, but unwraps the raw result and returns only the response and success value"
-  [query conn]
-  (let [[{:keys [resp]} success?] (test-query-chan-raw query conn)]
-    [resp success?]))
 
 (deftest run-async-chan
   (with-open [conn (r/connect :db test-db)]
@@ -382,24 +376,24 @@
       (is (not success?)))
 
     (let [[resp success?] (test-query-chan (r/db-list) conn)]
-      (is (some #{test-db} (first resp)))
+      (is (some #{test-db} resp))
       (is success?))
 
     (let [[resp success?] (test-query-chan (-> (r/table test-table) (r/insert [{:name "Charizard"} {:name "Squirtle"}])) conn)]
-      (is (= 2 (:inserted (first resp))))
+      (is (= 2 (:inserted resp)))
       (is success?))
 
     (let [[resp success?] (test-query-chan (-> (r/table test-table) (r/order-by :name)) conn)]
-      (is (= "Charizard" (:name (first (first resp)))))
+      (is (= "Charizard" (:name (first resp))))
       (is success?))))
 
 (deftest close-chan
   (with-open [conn (r/connect :db test-db)]
     (let [{:keys [waiting]} conn
-          {:keys [control-chan token]} (r/run-chan (-> (r/db test-db) (r/table test-table) (r/changes)) conn (async/chan 10))]
+          {:keys [control-in-chan token]} (r/run-chan (-> (r/db test-db) (r/table test-table) (r/changes)) conn (async/chan 10))]
       (is (not (contains? waiting token)))
       (is (contains? (:waiting @conn) token))
-      (async/put! control-chan :stop)
+      (async/put! control-in-chan :stop)
       (Thread/sleep 200) ;; TODO: need a better way to do it than this, wait on control chan?
       (is (not (contains? (:waiting @conn) token))))))
 

--- a/test/rethinkdb/core_test.clj
+++ b/test/rethinkdb/core_test.clj
@@ -168,7 +168,7 @@
       (r/max [4 6]) 6
       (r/sum [3 4]) 7)))
 
-#_(deftest changefeeds
+(deftest changefeeds
     (with-open [conn (r/connect)]
       (let [changes (future
                       (-> (r/db test-db)

--- a/test/rethinkdb/core_test.clj
+++ b/test/rethinkdb/core_test.clj
@@ -140,7 +140,7 @@
       (r/max [4 6]) 6
       (r/sum [3 4]) 7)))
 
-(deftest changefeeds
+#_(deftest changefeeds
   (with-open [conn (r/connect)]
     (let [changes (future
                     (-> (r/db test-db)

--- a/test/rethinkdb/core_test.clj
+++ b/test/rethinkdb/core_test.clj
@@ -387,6 +387,14 @@
       (is (= "Charizard" (:name (first resp))))
       (is success?))))
 
+(deftest stress-test-chan
+  (with-open [conn (r/connect :db test-db)]
+    (r/run (-> (r/table test-table) (r/insert {:name "Squirtle"})) conn)
+    (let [queries (repeatedly 100 #(r/run-chan (r/table test-table) conn (async/chan 1)))]
+      (is (= 100 (count (into []
+                          (comp (map :result-chan) (map async/<!!) (filter identity))
+                          queries)))))))
+
 (deftest close-chan
   (with-open [conn (r/connect :db test-db)]
     (let [{:keys [waiting]} conn

--- a/test/rethinkdb/core_test.clj
+++ b/test/rethinkdb/core_test.clj
@@ -3,6 +3,7 @@
             [clojure.test :refer :all]
             [rethinkdb.query :as r]
             [rethinkdb.core :as core]
+            [clojure.core.async :as async]))
             [rethinkdb.net :as net]))
 
 (def test-db "cljrethinkdb_test")
@@ -358,6 +359,17 @@
                                   {:default false})
                         (r/get-field :name))
                     conn))))))
+
+(deftest run-async-chan
+  (with-open [conn (r/connect :db test-db)]
+    (let [{:keys [error-chan result-chan]} (r/run-chan (r/db-list) conn (async/chan 10))
+          [v p] (async/alts!! [error-chan result-chan] :priority true)]
+      (is (some #{test-db} v))
+      (is (= p result-chan)))
+    (let [{:keys [error-chan result-chan]} (r/run-chan (r/db-drop "cljrethinkdb_nonexistentdb") conn (async/chan 10))
+          [v p] (async/alts!! [error-chan result-chan] :priority true)]
+      (is (= "Database `cljrethinkdb_nonexistentdb` does not exist." v))
+      (is (= p error-chan)))))
 
 (deftest query-conn
   (is (do (r/connect)

--- a/test/rethinkdb/core_test.clj
+++ b/test/rethinkdb/core_test.clj
@@ -369,7 +369,15 @@
     (let [{:keys [error-chan result-chan]} (r/run-chan (r/db-drop "cljrethinkdb_nonexistentdb") conn (async/chan 10))
           [v p] (async/alts!! [error-chan result-chan] :priority true)]
       (is (= "Database `cljrethinkdb_nonexistentdb` does not exist." v))
-      (is (= p error-chan)))))
+      (is (= p error-chan)))
+    (let [{:keys [result-chan error-chan]} (r/run-chan (-> (r/table test-table) (r/insert {:name "Charizard"})) conn (async/chan 10))
+          [v p] (async/alts!! [error-chan result-chan] :priority true)]
+      (is (= p result-chan))
+      (is (= 1 (:inserted v))))
+    (let [{:keys [result-chan error-chan]} (r/run-chan (-> (r/table test-table)) conn (async/chan 10))
+          [v p] (async/alts!! [error-chan result-chan] :priority true)]
+      (is (= p result-chan))
+      (is (= "Charizard" (:name v))))))
 
 (deftest close-chan
   (with-open [conn (r/connect :db test-db)]

--- a/test/rethinkdb/test_util.clj
+++ b/test/rethinkdb/test_util.clj
@@ -1,0 +1,27 @@
+(ns rethinkdb.test-util
+  (:require [rethinkdb.query :as r]
+            [clojure.core.async :as async]))
+
+(def test-db "cljrethinkdb_test")
+(def test-db-chan "cljrethinkdb_test_chan")
+(def test-table :pokedex)
+
+(defn ensure-table
+  "Ensures that an empty table \"table-name\" exists"
+  [db-name table-name optargs conn]
+  (if (some #{table-name} (r/run (r/table-list) conn))
+    (r/run (-> (r/table table-name) (r/delete)) conn)
+    (r/run (r/table-create (r/db db-name) table-name optargs) conn))) ;; (r/table-drop table-name)
+
+(defn ensure-db
+  "Ensures that an empty database \"db-name\" exists"
+  [db-name conn]
+  (if (not (some #{db-name} (r/run (r/db-list) conn)))
+    (r/run (r/db-create db-name) conn)))
+
+(defn altout
+  "Returns v if it gets a value from the channel, else :timeout" ;; TODO: better docstring
+  [ch]
+  (async/alt!! :priority true
+               (async/go (async/<! ch)) ([v] v)
+               (async/timeout 10) ([v] :timeout)))


### PR DESCRIPTION
I deleted my fork of the clj-rethinkdb repo and didn't realise I still had `async-chan` on it. Reopening the PR from #37 here.

This PR adds support for a core.async channel API. It also rearranges a few things to make them tidier and easier to use from two different run functions. Of particular note, **this upgrades protocol support to v4**. This gives us the benefit of "long-polling" the TCP socket when we are `:CONTINUE`ing, rather than having to keep sending queries every 500ms. More detail about this is at https://github.com/rethinkdb/rethinkdb/issues/4400#issuecomment-112222084

This PR isn't finished yet, in particular it needs

- [ ] Documentation and a docstring, including a discussion of backpressure
- [x] Update the changelog
- [x] Tests
- [x] Testing from other people
- [x] A better understanding of the failure cases and how to recover from them. There is an :error-channel provided, but nothing will ever be put on it presently
- [x] A way to shut down queries *and* close the core.async channel the user is reading from when the connection is closed
- [x] Discussion about the API for this, in particular about how to provide channels and arity order. Should the user be able to provide an `:error-channel` and `:control-channel` too?
- [x] Probably moving `run-query-chan` to the `rethinkdb.query` namespace or adding a helper function
- [x] Discussion about a possible future async and current sync run API's. I think it might work well to build the other two on top of the core.async channel API, as there is subtle logic around `:CONTINUE` queries and we don't want to do this more than once. Alternatively I can imagine that there could be an async API which the other two layer on top of, but I'm not sure how it would actually work with `:CONTINUE` queries.
- [x] Discussion about using manifold instead of core.async for async work.
- [x] Testing of v4 protocol differences with v3
- [x] Fix broken tests
- [x] Send the type of changefeed along with the message
- [ ] Create a buffered channel API which lets the user select how many results they want buffered ahead.
- [ ] Add a lazy-seq API on top of the async-chan API
- [ ] Add a callback based API on top of the async-chan API
- [x] Disconnecting the RethinkDB database causes a flurry of logging messages: `23:58:57.882 TRACE rethinkdb.net - Received raw response %s [0 ]`. This is because it's trying to `read` on the socket. This is likely a pre-existing condition, but need to check it out further.