### PR TITLE
Fix reflection warnings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :codox {:defaults {:doc/format :markdown}
           :src-dir-uri "https://github.com/apa512/clj-rethinkdb/blob/master/"
           :src-linenum-anchor-prefix "L"}
+  :global-vars {*warn-on-reflection* true}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
                  [org.clojure/data.json "0.2.6"]

--- a/src/rethinkdb/core.clj
+++ b/src/rethinkdb/core.clj
@@ -25,7 +25,7 @@
   "Closes RethinkDB database connection, stops all running queries
   and waits for response before returning"
   [conn]
-  (let [{:keys [socket out in waiting]} @conn]
+  (let [{:keys [^Socket socket ^DataOutputStream out ^DataInputStream in waiting]} @conn]
     (doseq [token waiting]
       (send-stop-query conn token))
     (close-connection-loops conn)
@@ -47,11 +47,11 @@
 (defn connection [m]
   (->Connection (atom m)))
 
-(defn connect
+(defn ^Connection connect
   "Creates a database connection to a RethinkDB host.
   If db is supplied, it is used in any queries where a db
   is not explicitly set."
-  [& {:keys [host port token auth-key db]
+  [& {:keys [^String host ^int port token auth-key db]
       :or {host "127.0.0.1"
            port 28015
            token 0

--- a/src/rethinkdb/query.clj
+++ b/src/rethinkdb/query.clj
@@ -28,7 +28,7 @@
 
 ;;; Import connect
 
-(def connect
+(def ^Connection connect
   "Creates a database connection to a RethinkDB host
   [& {:keys [host port token auth-key db]
        :or {host \"127.0.0.1\"

--- a/src/rethinkdb/utils.clj
+++ b/src/rethinkdb/utils.clj
@@ -9,14 +9,14 @@
       (.putInt i))
     (.array buf)))
 
-(defn str->bytes [s]
+(defn str->bytes [^String s]
   (let [n (count s)
         buf (ByteBuffer/allocate n)]
     (doto buf
       (.put (.getBytes s)))
     (.array buf)))
 
-(defn bytes->int [bs n]
+(defn bytes->int [^bytes bs n]
   (let  [buf (ByteBuffer/allocate (or n 4))]
     (doto buf
       (.order ByteOrder/LITTLE_ENDIAN)


### PR DESCRIPTION
This fixes almost all reflection warnings in clj-rethinkdb, except for reflections done by libraries and Protocol Buffer interop (this will be fixed in https://github.com/apa512/rethinkdb-protobuf/pull/3).