### PR TITLE
Add clojure.tools.logging and logging statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com).
 
 ## [Unreleased]
+### Added
+- Added clojure.tools.logging support. [#72](https://github.com/apa512/clj-rethinkdb/pull/72)
 
 ## [0.10.1] - 2015-07-08
 ### Added

--- a/project.clj
+++ b/project.clj
@@ -11,9 +11,11 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
                  [org.clojure/data.json "0.2.6"]
+                 [org.clojure/tools.logging "0.3.1"]
                  [rethinkdb-protobuf "2.0.5-20150720.090807-2"]
                  [com.google.protobuf/protobuf-java "2.6.1"]
                  [clj-time "0.10.0"]]
+  :profiles {:dev {:dependencies [[ch.qos.logback/logback-classic "1.1.3"]]}}
   :release-tasks [["vcs" "assert-committed"]
                   ["change" "version" "leiningen.release/bump-version" "release"]
                   ["vcs" "commit"]

--- a/src/rethinkdb/core.clj
+++ b/src/rethinkdb/core.clj
@@ -1,5 +1,6 @@
 (ns rethinkdb.core
-  (:require [rethinkdb.net :refer [send-int send-str read-init-response send-stop-query make-connection-loops close-connection-loops]])
+  (:require [rethinkdb.net :refer [send-int send-str read-init-response send-stop-query make-connection-loops close-connection-loops]]
+            [clojure.tools.logging :as log])
   (:import [clojure.lang IDeref]
            [java.io Closeable DataInputStream DataOutputStream]
            [java.net Socket]))
@@ -91,4 +92,5 @@
            :token token}
           (make-connection-loops in out))))
     (catch Exception e
+      (log/error e "Error connecting to RethinkDB database")
       (throw (ex-info "Error connecting to RethinkDB database" {:host host :port port :auth-key auth-key :db db} e)))))

--- a/test-resources/logback-test.xml
+++ b/test-resources/logback-test.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Library users will need to provide a clojure.tools.logging compatible logger to see these logs, we don't bundle logback so we can let the user choose. Similarly, they will need to provide their own logging config, as our one is in test-resources and won't be packaged in the JAR.