### PR TITLE
Modify index-create to allow simple indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file. This change
 - Update protobuf support to RethinkDB 2.1.0.
 - Update docstring for `rethinkdb.query/without`.
 - Update arity and docstring for `rethinkdb.query/merge` to support merging any number of objects.
+- Add new arity to `rethinkdb.query/index-create` to allow creating simple indexes from field names. [#86](https://github.com/apa512/clj-rethinkdb/pull/86)
 
 ## [0.10.1] - 2015-07-08
 ### Added

--- a/src/rethinkdb/query.cljc
+++ b/src/rethinkdb/query.cljc
@@ -84,9 +84,13 @@
    (term :TABLE_LIST [db])))
 
 (defn index-create
-  "Create a new secondary index on a table."
-  [table index-name func & [optargs]]
-  (term :INDEX_CREATE [table index-name func] optargs))
+  "Create a new secondary index on a table. To create a simple index based on the
+  value of a single field, pass the field as the index-name. If you need to
+  pass optargs without a function, then set func to nil."
+  [table index-name & [func optargs]]
+  (if (some? func)
+    (term :INDEX_CREATE [table index-name func] optargs)
+    (term :INDEX_CREATE [table index-name] optargs)))
 
 (defn index-drop
   "Delete a previously created secondary index."
@@ -634,13 +638,13 @@
   (term :NOW []))
 
 (defn time
-   "Create a time object for a specific time."
-        [& date-time-parts]
-   (let [args (concat date-time-parts
-                      (if (string? (last date-time-parts))
-                        []
-                        ["+00:00"]))]
-     (term :TIME args)))
+  "Create a time object for a specific time."
+  [& date-time-parts]
+  (let [args (concat date-time-parts
+                     (if (string? (last date-time-parts))
+                       []
+                       ["+00:00"]))]
+    (term :TIME args)))
 
 (defn epoch-time
   "Create a time object based on seconds since epoch. The first argument is a

--- a/test/rethinkdb/core_test.clj
+++ b/test/rethinkdb/core_test.clj
@@ -63,13 +63,14 @@
           (r/insert {:id (java.util.UUID/randomUUID)})) {:inserted 1}
       (r/table-drop (r/db test-db) :tmp) {:tables_dropped 1}
       (r/table-drop :tmp2) {:tables_dropped 1}
+      (-> (r/table test-table) (r/index-create :name)) {:created 1}
       (-> (r/table test-table) (r/index-create :tmp (r/fn [row] 1))) {:created 1}
       (-> (r/table test-table)
           (r/index-create :type (r/fn [row]
                                   (r/get-field row :type)))) {:created 1}
       (-> (r/table test-table) (r/index-rename :tmp :xxx)) {:renamed 1}
       (-> (r/table test-table) (r/index-drop :xxx)) {:dropped 1})
-    (is (= ["type"] (r/run (-> (r/table test-table) r/index-list) conn)))))
+    (is (= ["name" "type"] (r/run (-> (r/table test-table) r/index-list) conn)))))
 
 (deftest manipulating-data
   (with-open [conn (r/connect :db test-db)]


### PR DESCRIPTION
Simple indexes are based on the value of a single field, and can be created by passing the field name as the name of the index.

N.B. You can create an index on a field that doesn't 'exist', because RethinkDB has no notion of a schema and therefore no ability to tell whether a field will be present in the future or an index is 'valid' when it is created.

I'm not 100% happy with the switching on whether `func` is nil, but I don't really see any other way to accomplish this while keeping optargs optional. Happy to hear other ideas though.

Fixes #83