### PR TITLE
Prefix RethinkDB server exceptions with `RethinkDB server: `

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. This change
 - Disable Nagle's algorithm (set TCP NO_DELAY to true). This provides a speedup of around 30-40x for small queries on Linux. [#114](https://github.com/apa512/clj-rethinkdb/pull/114)
 - Added a new arity to `changes` that allows you to pass optargs. [#112](https://github.com/apa512/clj-rethinkdb/issues/112)
 - Renamed changes arg from `table` to `xs`. [#76](https://github.com/apa512/clj-rethinkdb/issues/76)
+- Prefix RethinkDB server exceptions with `RethinkDB server:`. [#100](https://github.com/apa512/clj-rethinkdb/pull/100)
 
 
 ## [0.11.0] - 2015-10-19

--- a/src/rethinkdb/net.clj
+++ b/src/rethinkdb/net.clj
@@ -120,7 +120,7 @@
                (do
                  (swap! (:conn conn) update-in [:waiting] #(conj % token))
                  (Cursor. conn token resp)))
-      (let [ex (ex-info (str (first resp)) json-resp)]
+      (let [ex (ex-info (str "RethinkDB server: " (first resp)) json-resp)]
         (log/error ex)
         (throw ex)))))
 


### PR DESCRIPTION
It is sometimes difficult for people to distinguish between an exception
thrown in the client library, and an exception from the server which is
sent back and thrown by the client library. This change prefixes
serverside exceptions to make this distinction clearer.

Fixes #95, fixes #94