### PR TITLE
Change Group ID from rethinkdb to com.apa512

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file. This change
 - `rethinkdb.query/default` function, for supplying a default value/function for missing values. [90b58cd](https://github.com/apa512/clj-rethinkdb/commit/90b58cd14179fb4eec6e8a28387fe4eda1397adb)
 
 ### Changed
+- Change Maven Group ID from `rethinkdb` to `com.apa512`. [#102](https://github.com/apa512/clj-rethinkdb/pull/102), [#92](https://github.com/apa512/clj-rethinkdb/issues/92)
 - Update dependency to Clojure 1.7. [#59](https://github.com/apa512/clj-rethinkdb/pull/59)
 - The query parts of this library have been converted to use Clojure 1.7 Reader Conditionals. This means that you can generate queries in ClojureScript and run them on the server (be very careful with this!). [#59](https://github.com/apa512/clj-rethinkdb/pull/59)
 - Update protobuf support to RethinkDB 2.1.0.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A RethinkDB client for Clojure. Tested and supported on RethinkDB 2.0.x but shou
 
 ## Install
 
-[![Clojars Project](http://clojars.org/rethinkdb/latest-version.svg)](http://clojars.org/rethinkdb)
+[![Clojars Project](http://clojars.org/com.apa512/rethinkdb/latest-version.svg)](http://clojars.org/com.apa512/rethinkdb)
 
 ## Changes
 
@@ -25,12 +25,12 @@ All changes are published in the [CHANGELOG](CHANGELOG.md). Of particular note, 
   (-> (r/db "test")
       (r/table-create "authors")
       (r/run conn))
-       
+
   (comment "This is equivalent to the previous query; db on connection is implicitly
   used if no db is provided."
   (-> (r/table-create "authors")
       (r/run conn)))
-      
+
   ;; Create an index on the field "genre".
   (-> (r/db "test")
       (r/table "authors")

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject rethinkdb "0.11.0-SNAPSHOT"
+(defproject com.apa512/rethinkdb "0.11.0-SNAPSHOT"
   :description "RethinkDB client"
   :url "http://github.com/apa512/clj-rethinkdb"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
We don't want people to get confused between the official Java RethinkDB driver and this driver.

This probably shouldn't be merged until we're ready to release the next version, as it changes the URL and SVG of Clojars links.

Fixes #92