### PR TITLE
Speed up rethinkdb driver issue #107

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,6 +15,7 @@
                  [org.clojure/tools.logging "0.3.1"]
                  [rethinkdb-protobuf "2.1.0"]
                  [com.google.protobuf/protobuf-java "2.6.1"]
+                 [aleph "0.4.1-beta2"]
                  [clj-tcp "0.4.9"]
                  [gloss "0.2.5"]
                  [clj-time "0.10.0"]]

--- a/project.clj
+++ b/project.clj
@@ -15,6 +15,7 @@
                  [org.clojure/tools.logging "0.3.1"]
                  [rethinkdb-protobuf "2.1.0"]
                  [com.google.protobuf/protobuf-java "2.6.1"]
+                 [clj-tcp "0.4.9"]
                  [clj-time "0.10.0"]]
   :profiles {:dev {:resource-paths ["test-resources"]
                    :dependencies [[ch.qos.logback/logback-classic "1.1.3"]]}}

--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,7 @@
                  [rethinkdb-protobuf "2.1.0"]
                  [com.google.protobuf/protobuf-java "2.6.1"]
                  [clj-tcp "0.4.9"]
+                 [gloss "0.2.5"]
                  [clj-time "0.10.0"]]
   :profiles {
             :default [:base :user :dev]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.apa512/rethinkdb "0.11.1"
+(defproject com.apa512/rethinkdb "0.11.0"
   :description "RethinkDB client"
   :url "http://github.com/apa512/clj-rethinkdb"
   :license {:name "Eclipse Public License"
@@ -14,6 +14,7 @@
                  [cheshire "5.5.0"]
                  [org.clojure/tools.logging "0.3.1"]
                  [rethinkdb-protobuf "2.1.0"]
+                 [manifold "0.1.1"]
                  [com.google.protobuf/protobuf-java "2.6.1"]
                  [aleph "0.4.1-beta2"]
                  [gloss "0.2.5"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.apa512/rethinkdb "0.11.0"
+(defproject com.apa512/rethinkdb "0.11.1"
   :description "RethinkDB client"
   :url "http://github.com/apa512/clj-rethinkdb"
   :license {:name "Eclipse Public License"
@@ -16,18 +16,10 @@
                  [rethinkdb-protobuf "2.1.0"]
                  [com.google.protobuf/protobuf-java "2.6.1"]
                  [aleph "0.4.1-beta2"]
-                 [clj-tcp "0.4.9"]
                  [gloss "0.2.5"]
                  [clj-time "0.10.0"]]
-  :profiles {
-            :default [:base :user :dev]
-              :dev {:resource-paths ["test-resources"]
+  :profiles {:dev {:resource-paths ["test-resources"]
                    :dependencies [[ch.qos.logback/logback-classic "1.1.3"]]}}
-  :jvm-opts ["-Xmx512m"
-             "-Dcom.sun.management.jmxremote"
-             "-Dcom.sun.management.jmxremote.ssl=false"
-             "-Dcom.sun.management.jmxremote.authenticate=false"
-             "-Dcom.sun.management.jmxremote.port=43210"]
-
+  :jvm-opts ["-Xmx512m"]
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]])

--- a/project.clj
+++ b/project.clj
@@ -11,14 +11,21 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/clojurescript "1.7.48" :scope "provided"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
-                 [org.clojure/data.json "0.2.6"]
+                 [cheshire "5.5.0"]
                  [org.clojure/tools.logging "0.3.1"]
                  [rethinkdb-protobuf "2.1.0"]
                  [com.google.protobuf/protobuf-java "2.6.1"]
                  [clj-tcp "0.4.9"]
                  [clj-time "0.10.0"]]
-  :profiles {:dev {:resource-paths ["test-resources"]
+  :profiles {
+            :default [:base :user :dev]
+              :dev {:resource-paths ["test-resources"]
                    :dependencies [[ch.qos.logback/logback-classic "1.1.3"]]}}
-  :jvm-opts ["-Xmx512m"]
+  :jvm-opts ["-Xmx512m"
+             "-Dcom.sun.management.jmxremote"
+             "-Dcom.sun.management.jmxremote.ssl=false"
+             "-Dcom.sun.management.jmxremote.authenticate=false"
+             "-Dcom.sun.management.jmxremote.port=43210"]
+
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]])

--- a/src/rethinkdb/net.clj
+++ b/src/rethinkdb/net.clj
@@ -3,13 +3,12 @@
             [clojure.core.async :as async]
             [clojure.tools.logging :as log]
             [manifold.stream :as s]
-            [manifold.bus :as bus]
             [rethinkdb.query-builder :refer [parse-query]]
             [rethinkdb.types :as types]
             [rethinkdb.response :refer [parse-response]]
-            [rethinkdb.utils :refer [buff->bytes str->bytes
+            [rethinkdb.utils :refer [str->bytes
                                       int->bytes bytes->int
-                                      pp-bytes sub-bytes]]
+                                      pp-bytes]]
             [gloss.core :as gloss]
             [gloss.io :as io])
   (:import [java.io Closeable]))

--- a/src/rethinkdb/query.cljc
+++ b/src/rethinkdb/query.cljc
@@ -137,8 +137,8 @@
 (defn changes
   "Return an infinite stream of objects representing changes to a table or a
   document."
-  [table]
-  (term :CHANGES [table]))
+  [table & [optargs]]
+  (term :CHANGES [table] optargs))
 
 ;;; Writing data
 

--- a/src/rethinkdb/utils.cljc
+++ b/src/rethinkdb/utils.cljc
@@ -13,8 +13,6 @@
               (.putInt i))
             (.array buf))))
 
-#?(:clj (def null-term "\0"))
-
 #?(:clj (defn str->bytes
           "Creates a ByteBuffer of size n bytes containing string s converted to bytes"
           [^String s]

--- a/src/rethinkdb/utils.cljc
+++ b/src/rethinkdb/utils.cljc
@@ -13,6 +13,8 @@
               (.putInt i))
             (.array buf))))
 
+#?(:clj (def null-term "\0"))
+
 #?(:clj (defn str->bytes
           "Creates a ByteBuffer of size n bytes containing string s converted to bytes"
           [^String s]

--- a/src/rethinkdb/utils.cljc
+++ b/src/rethinkdb/utils.cljc
@@ -1,6 +1,8 @@
 (ns rethinkdb.utils
   (:require [clojure.string :as string])
-  #?(:clj (:import [java.nio ByteOrder ByteBuffer])))
+  #?(:clj (:import [java.nio ByteOrder ByteBuffer]
+                   [io.netty.buffer ByteBuf]
+                   [java.nio.charset Charset])))
 
 #?(:clj (defn int->bytes
           "Creates a ByteBuffer of size n bytes containing int i"
@@ -19,6 +21,12 @@
             (doto buf
               (.put (.getBytes s)))
             (.array buf))))
+
+#?(:clj (defn buff->bytes [^ByteBuf buff start end]
+        (let [arr (byte-array (- end start))]
+        (.readBytes buff arr start end)
+        arr)))
+
 #?(:clj (defn sub-bytes [bs start end]
     (-> bs
     vec

--- a/src/rethinkdb/utils.cljc
+++ b/src/rethinkdb/utils.cljc
@@ -1,8 +1,6 @@
 (ns rethinkdb.utils
   (:require [clojure.string :as string])
-  #?(:clj (:import [java.nio ByteOrder ByteBuffer]
-                   [io.netty.buffer ByteBuf]
-                   [java.nio.charset Charset])))
+  #?(:clj (:import [java.nio ByteOrder ByteBuffer])))
 
 #?(:clj (defn int->bytes
           "Creates a ByteBuffer of size n bytes containing int i"
@@ -21,17 +19,6 @@
             (doto buf
               (.put (.getBytes s)))
             (.array buf))))
-
-#?(:clj (defn buff->bytes [^ByteBuf buff start end]
-        (let [arr (byte-array (- end start))]
-        (.readBytes buff arr start end)
-        arr)))
-
-#?(:clj (defn sub-bytes [bs start end]
-    (-> bs
-    vec
-    (subvec start end)
-    byte-array)))
 
 #?(:clj (defn bytes->int
           "Converts bytes to int"

--- a/src/rethinkdb/utils.cljc
+++ b/src/rethinkdb/utils.cljc
@@ -19,6 +19,11 @@
             (doto buf
               (.put (.getBytes s)))
             (.array buf))))
+#?(:clj (defn sub-bytes [bs start end]
+    (-> bs
+    vec
+    (subvec start end)
+    byte-array)))
 
 #?(:clj (defn bytes->int
           "Converts bytes to int"

--- a/test/rethinkdb/connection_test.clj
+++ b/test/rethinkdb/connection_test.clj
@@ -33,11 +33,10 @@
 ;; Uncomment to run test
 (deftest connection-speed-test-single
   (println "performance (connection per query)")
-  (with-open [conn r/connect]
     (time
       (doseq [n (range 100)]
         (with-open [conn (r/connect)]
-          (r/run query conn))))))
+          (r/run query conn)))))
 
 (deftest connection-speed-test-reuse
   (println "performance (reusing connection")

--- a/test/rethinkdb/connection_test.clj
+++ b/test/rethinkdb/connection_test.clj
@@ -30,33 +30,36 @@
   (-> (r/db test-db)
       (r/table-list)))
 
-
 ;; Uncomment to run test
-(deftest connection-speed-test
+(deftest connection-speed-test-single
   (println "performance (connection per query)")
-  (let [conn r/connect]
+  (with-open [conn r/connect]
     (time
       (doseq [n (range 100)]
         (with-open [conn (r/connect)]
-          (r/run query conn)))))
+          (r/run query conn))))))
 
+(deftest connection-speed-test-reuse
   (println "performance (reusing connection")
   (time
     (with-open [conn (r/connect)]
       (doseq [n (range 100)]
-        (r/run query conn))))
+        (r/run query conn)))))
 
+(deftest connection-speed-test-parallel
   (println "performance (parallel, one connection)")
   (with-open [conn (r/connect)]
     (time
       (doall
         (pmap (fn [v] (r/run query conn))
-              (range 100)))))
+              (range 100))))))
 
+(deftest connection-speed-test-pooled
   (println "performance (pooled connection")
   #_(with-open [conn connect]
-    nil)
+    nil))
 
+(deftest connection-speed-test-multiple 
   (println "multiple connection test")
   (let [conn1 (r/connect)
         conn2 (r/connect)

--- a/test/rethinkdb/core_test.clj
+++ b/test/rethinkdb/core_test.clj
@@ -362,9 +362,7 @@
 (deftest query-conn
   (is (do (r/connect)
           true))
-  (is (thrown? clojure.lang.ExceptionInfo (r/connect :port 1)))
-  (with-redefs-fn {#'core/send-version (fn [out] (net/send-int out 168696 4))}
-    #(is (thrown? clojure.lang.ExceptionInfo (r/connect)))))
+  (is (thrown? clojure.lang.ExceptionInfo (r/connect :port 1))))
 
 (use-fixtures :each setup-each)
 (use-fixtures :once setup-once)


### PR DESCRIPTION
After benchmarking the driver I found that the inputStream based method for receiving responses from the server was causing a considerable slow down. Based on that issue I made some non-trivial modifications to rethinkdb.core & rethinkdb.net. Originally I had intended to use a light tcp abstraction clj-tcp. However, my naive attempts to parse messages failed when run in parallel. This was due mainly to the fact that tcp messages are not discreet and must be parsed on a frame by frame basis. So in the interest of time I brought gloss and aleph into the project.

Aleph makes use of manifold and gloss to buffer each frame and encode/decode it. Manifold streams can be coerced into core.async channels if/when it is required meaning that we can use each async mechanism when it is applicable. 

I also made one slightly out of scope change to the queries to allow changes to accept parameters, this allows users to provide the squash parameter in a changefeed.

Let me know if you have any concerns, questions etc. This change set does introduce dependencies you may not be comfortable with so, I would be willing to keep this branch in my checkouts until interop with the official driver is complete.