### PR TITLE
Disable TCP delay (Nagle's algorithm)

### DIFF
--- a/src/rethinkdb/core.clj
+++ b/src/rethinkdb/core.clj
@@ -74,6 +74,8 @@
     (let [socket (Socket. host port)
           out (DataOutputStream. (.getOutputStream socket))
           in (DataInputStream. (.getInputStream socket))]
+      ;; Disable Nagle's algorithm on the socket
+      (.setTcpNoDelay socket true)
       ;; Initialise the connection
       (send-version out)
       (send-auth-key out auth-key)


### PR DESCRIPTION
Nagle's algorithm (https://en.wikipedia.org/wiki/Nagle's_algorithm) appears to delay the transmission of TCP packages due to the particular pattern of write and read operations in this driver. This patch disables it (all of our official drivers do the same).

This is the first time I've been using Clojure, so please let me know if there is a better way of doing this or if there are any style problems with my patch.

This is how I tested it:
```clojure
(deftest loop
  (with-open [conn (r/connect :host "127.0.0.1" :port 28015 :db "test")]
    (dorun (for [i (range 1000)]
        (println (-> (r/add i 0)
                     (r/run conn)))
    ))
  )
)
```

At least on Linux, this test runs very slowly without the patch (each operation takes about 40ms). With the patch, each operation takes less than 1 ms.