### PR TITLE
UTF-8 strings

### DIFF
--- a/src/rethinkdb/net.clj
+++ b/src/rethinkdb/net.clj
@@ -32,8 +32,9 @@
   (.write out (int->bytes i n) 0 n))
 
 (defn send-str [^OutputStream out s]
-  (let [n (count s)]
-    (.write out (str->bytes s) 0 n)))
+  (let [bytes (str->bytes s)
+        n (count bytes)]
+    (.write out bytes 0 n)))
 
 (defn read-str [^DataInputStream in n]
   (let [resp (byte-array n)]
@@ -43,8 +44,7 @@
 (defn ^String read-init-response [^InputStream in]
   (let [resp (byte-array 4096)]
     (.read in resp 0 4096)
-    (clojure.string/replace (String. resp) #"\W*$" "")))
-
+    (clojure.string/replace (String. resp "UTF-8") #"\W*$" "")))
 
 (defn read-response* [^InputStream in]
   (let [recvd-token (byte-array 8)
@@ -58,7 +58,7 @@
 
 (defn write-query [out [token json]]
   (send-int out token 8)
-  (send-int out (count json) 4)
+  (send-int out (count (str->bytes json)) 4)
   (send-str out json))
 
 (defn make-connection-loops [in out]

--- a/src/rethinkdb/utils.cljc
+++ b/src/rethinkdb/utils.cljc
@@ -14,11 +14,7 @@
 #?(:clj (defn str->bytes
           "Creates a ByteBuffer of size n bytes containing string s converted to bytes"
           [^String s]
-          (let [n (count s)
-                buf (ByteBuffer/allocate n)]
-            (doto buf
-              (.put (.getBytes s)))
-            (.array buf))))
+          (.getBytes s "UTF-8")))
 
 #?(:clj (defn bytes->int
           "Converts bytes to int"

--- a/test/rethinkdb/core_test.clj
+++ b/test/rethinkdb/core_test.clj
@@ -424,5 +424,13 @@
          (is (= ""
                 (:auth-key (ex-data e)))))))
 
+(deftest utf8-compliance
+  (with-open [conn (r/connect :db test-db)]
+    (is (= (-> (r/table test-table)
+               (r/insert [{:text "üöä"}])
+               (r/run conn)
+               :inserted)
+           1))))
+
 (use-fixtures :each setup-each)
 (use-fixtures :once setup-once)


### PR DESCRIPTION
RethinkDB requires Drivers to "Serialize the query as UTF8-encoded JSON"