### PR TITLE
README: Add upsert with created/updated time example

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,5 +149,40 @@ In Clojure this would be
 note particularly that `returnChanges` is written as `:return-changes` in Clojure.
 
 
+### Advanced Operations
+
+#### Upsert while maintaining created / updated times
+
+An example using loops, functions, branching and various object operations (select, add & remove fields).
+
+`upsert-xs!` takes a list of items `[{:id 'item-1', ...}, {:id 'item-2', ...}, ...]` and insert them if the id was not present in the database before. Or does an update if the item already exists.
+
+```clj
+(defn upsert-items! [items]
+  (let [table (r/table "my-table")]
+    (-> items
+        (r/for-each
+          (r/fn [item]
+              ;; Find a document using the upsert'd item id.
+              (let [doc (r/get table (r/get-field item :id))]
+                (r/branch (r/eq nil doc)
+                  ;; item is new, set its updated/created time and insert it.
+                  (r/insert table
+                            (r/merge {:updated (r/now) :created (r/now)} item)
+                            {:conflict "update"})
+                  ;; item already exists, set the updated time and update the doc,
+                  ;; Take care of removing the id in the update-object to avoid upsetting RethinkDB.
+                  (r/update doc
+                            (r/merge {:updated (r/now)} (r/without item [:id])))))))
+      (r/run conn))))
+```
+
+Note that for inserts we resolve conflicts by an update. At worst this may override an object that has been added while the query was running. Which should never happen since this function is recognized by RethinkDB as atomic.
+
+Also note that the ordering in `r/merge` is important, preference is given to fields in the rightmost object in the argument list. The upsert'd items can define a default `:updated` and `:created` field that'll override `(r/now)`.
+
+
+### Complete Reference
+
 See full documentation at http://apa512.github.io/clj-rethinkdb/ (work in progress).
 


### PR DESCRIPTION
- It took me quite some time to understand how to do an upsert that does not override
  some fields in the previous document. And keeping the query atomic.
- Share back the result.