### PR TITLE
Add type hint to remove reflection warning

### DIFF
--- a/src/rethinkdb/query_builder.cljc
+++ b/src/rethinkdb/query_builder.cljc
@@ -45,7 +45,7 @@
 
 #?(:clj (defmethod parse-arg :binary [arg]
           {"$reql_type$" "BINARY"
-           "data" (String. (base64/encode arg) "UTF-8")}))
+           "data" (String. ^bytes (base64/encode arg) "UTF-8")}))
 
 (defmethod parse-arg :uuid [arg]
   (str arg))


### PR DESCRIPTION
Reflection warning, clj-rethinkdb/src/rethinkdb/query_builder.cljc:48:19 - call to java.lang.String ctor can't be resolved.