### PR TITLE
Makes get-all api consistent with reql by accepting non coll argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The clj-rethinkdb query API aims to match the [JavaScript](http://rethinkdb.com/
   ;; Use the "genre" index we created to get all books with the genre of "crap".
   (-> (r/db "test")
       (r/table "authors")
-      (r/get-all ["crap"] {:index "genre"})
+      (r/get-all "crap" {:index "genre"})
       (r/filter (r/fn [row]
                   (r/eq "Stephenie Meyer" (r/get-field row "name"))))
       (r/run conn))

--- a/src/rethinkdb/query.cljc
+++ b/src/rethinkdb/query.cljc
@@ -219,9 +219,10 @@
   index."
   [table ids & [optargs]]
   (term :GET_ALL
-        (if (map? ids)
-          [table (wrap-args ids)]
-          (concat [table] ids))
+        (cond
+          (map? ids) [table (wrap-args ids)]
+          (coll? ids) (concat [table] ids)
+          :else [table ids])
         optargs))
 
 (defn get-field

--- a/test/rethinkdb/core_test.clj
+++ b/test/rethinkdb/core_test.clj
@@ -123,6 +123,7 @@
       (is (= (set (r/run (r/table test-table) conn)) (set pokemons)))
       (is (= (r/run (-> (r/table test-table) (r/get 25)) conn) (first pokemons)))
       (is (= (set (r/run (-> (r/table test-table) (r/get-all [25 81])) conn)) (set pokemons)))
+      (is (= (first (r/run (-> (r/table test-table) (r/get-all 25)) conn)) (first (set pokemons))))
       (is (= pokemons (sort-by :national_no (r/run (-> (r/table test-table)
                                                      (r/between r/minval r/maxval {:right-bound :closed})) conn))))
       (is (= (r/run (-> (r/table test-table)


### PR DESCRIPTION
Reql expects an argument list for get-all, so it can either be a collection or a single value. 

Clojure has no way (that I know of) to receive an undefined number of arguments as a 'middle' argument and the last argument needs to be the options so remainder won't work.

This tiny PR makes sure you can pass a single value as arg to get-all so it gets closer to reql and uses a cond to ensure that.
It won't break previous implementations and for composite keys it will keep the old behaviour (nested array) since there's no unambiguous way to turn around it (again - that I know of).

(motivation: spent an hour trying to figure out what was wrong in an update - turns out, was not passing a coll but a single string - it's on me, but this stops it from happening to someone else :) )