### PR TITLE
Extract logic for whether a query is async or not

### DIFF
--- a/src/rethinkdb/net.clj
+++ b/src/rethinkdb/net.clj
@@ -167,6 +167,10 @@
             (s/put! client (io/encode query-protocol [token json])))
           (recur))))))
 
+(defn async-query? [opts conn]
+  (let [not-found (:async? conn)]
+    (get opts :async? not-found)))
+
 ;;; ========================================================================
 ;;; Sending initial query
 ;;; ========================================================================
@@ -196,10 +200,7 @@
                                   :token token})))
 
 (defn send-start-query [conn term & [opts]]
-  (let [async? (->> [opts @conn]
-                    (map :async?)
-                    (remove nil?)
-                    first)]
+  (let [async? (async-query? opts @conn)]
     (send-initial-query conn {:term term
                               :query-type :START
                               :async? async?})))

--- a/test/rethinkdb/async_test.clj
+++ b/test/rethinkdb/async_test.clj
@@ -1,0 +1,22 @@
+(ns rethinkdb.async-test
+  (:require [clojure.test :refer :all]
+            [rethinkdb.net :as net]))
+
+(deftest async-query?-test
+  (are [async? opts conn]
+    (= async? (boolean (net/async-query? opts conn)))
+
+    ;; Synchornous queries
+    false nil {}
+    false nil {:async? false}
+    false {} {}
+    false {} {:async? false}
+    false {:async? false} {}
+    false {:async? false} {:async? false}
+    false {:async? false} {:async? true}
+
+    ;; Asynchronous queries
+    true nil {:async? true}
+    true {} {:async? true}
+    true {:async? true} {}
+    true {:async? true} {:async? true}))


### PR DESCRIPTION
- Extract logic into async-query?
- Add tests to cover all possible combinations of query opts and conn opts
- Fix bug when `opts={}` and `conn={:async? true}`, query would be run synchronously.