### PR TITLE
Persist milliseconds of DateTimes

### DIFF
--- a/src/rethinkdb/query_builder.cljc
+++ b/src/rethinkdb/query_builder.cljc
@@ -43,7 +43,7 @@
   (zipmap (keys arg) (map parse-arg (vals arg))))
 
 (defmethod parse-arg :time [arg]
-  (parse-term (term :EPOCH_TIME [#?(:clj (c/to-epoch arg)
+  (parse-term (term :EPOCH_TIME [#?(:clj (double (/ (c/to-long arg) 1000))
                                     :cljs (.getTime arg))])))
 
 #?(:clj (defmethod parse-arg :binary [arg]


### PR DESCRIPTION
clj-time's to-epoch function returns the number of seconds since epoch,
which truncates the milliseconds of DateTime. Use to-long, which returns
milliseconds since epoch, and divide by 1000 in order to properly format
this number